### PR TITLE
feat(protocols): migrate sable protocols

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
   name: "Obsidian",
+  platforms: [
+    .macOS(.v10_15),
+  ],
   products: [
     .library(name: "Obsidian", targets: ["Obsidian"]),
   ],

--- a/Sources/Protocols/Describable.swift
+++ b/Sources/Protocols/Describable.swift
@@ -1,0 +1,34 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A protocol that provides a textual description of an object.
+///
+/// `Describable` offers a consistent way to get a human-readable description
+/// of types. This can be used for logging, debugging, or displaying information to users.
+///
+/// ```swift
+/// struct Message: Describable {
+///   let sender: String
+///   let content: String
+///
+///   var description: String {
+///     return "\(sender): \(content)"
+///   }
+/// }
+///
+/// let message = Message(sender: "Alice", content: "Hello!")
+/// print(message.description)  // Prints "Alice: Hello!"
+/// ```
+///
+/// - Note: Unlike Swift's `CustomStringConvertible` protocol, `Describable` is designed
+///   to be used explicitly when a description is needed, rather than implicitly through
+///   string interpolation or printing.
+public protocol Describable {
+  /// A textual description of the instance.
+  ///
+  /// This property should provide a concise but informative description,
+  /// suitable for logging, debugging, or user-facing displays.
+  var description: String { get }
+}

--- a/Sources/Protocols/Namable.swift
+++ b/Sources/Protocols/Namable.swift
@@ -1,0 +1,51 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A protocol that provides a name for an object.
+///
+/// `Namable` provides a consistent way to access a human-readable name
+/// for types. By default, it returns the type name as a string, but conforming types
+/// can override this with a custom name.
+///
+/// ```swift
+/// struct Product: Namable {
+///   // Uses default implementation: returns "Product"
+/// }
+///
+/// struct CustomProduct: Namable {
+///   let name: String  // Custom implementation: returns this value
+///
+///   init(name: String) {
+///     self.name = name
+///   }
+/// }
+///
+/// let product = Product()
+/// print(product.name)  // Prints "Product"
+///
+/// let custom = CustomProduct(name: "Deluxe Widget")
+/// print(custom.name)   // Prints "Deluxe Widget"
+/// ```
+///
+/// - Note: The default implementation returns the type name without parentheses,
+///   using `String(describing: type(of: self))` rather than `String(describing: self)`.
+///   This provides a cleaner representation for logging and debugging.
+public protocol Namable {
+  /// A human-readable name for the instance.
+  ///
+  /// By default, this returns the type name as a string (e.g., "ClassName" or "GenericClass<Type>").
+  /// Conforming types can override this property to provide a custom name.
+  var name: String { get }
+}
+
+extension Namable {
+  /// Default implementation that returns the type name as a string.
+  ///
+  /// This implementation uses `String(describing: type(of: self))` to get the
+  /// type name without parentheses, for a cleaner representation.
+  public var name: String {
+    return String(describing: type(of: self))
+  }
+}

--- a/Sources/Protocols/Representable.swift
+++ b/Sources/Protocols/Representable.swift
@@ -1,0 +1,44 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A protocol that combines unique identification, naming, and description capabilities.
+///
+/// `Representable` unifies the `Uniquable`, `Namable`, and `Describable` protocols
+/// to provide a complete representation for an object. This creates a standardized
+/// way to identify, name, and describe types.
+///
+/// By default, a `Representable` object's description will be its name followed by
+/// its UUID, separated by a colon.
+///
+/// ```swift
+/// struct User: Representable {
+///   let id = UUID()
+///   // Uses default implementations for name and description
+/// }
+///
+/// struct CustomUser: Representable {
+///   let id = UUID()
+///   let name: String
+///
+///   // Description will still use the default implementation: "\(name):\(id)"
+/// }
+///
+/// let user = User()
+/// print(user.name)        // Prints "User"
+/// print(user.description) // Prints "User:73A67C13-ABCD-1234-EFGH-456789ABCDEF"
+/// ```
+///
+/// - Note: Types conforming to `Representable` automatically conform to
+///   `Uniquable`, `Namable`, and `Describable`, gaining all their functionality.
+public protocol Representable: Uniquable, Namable, Describable {}
+
+extension Representable {
+  /// Default implementation of description that combines name and ID.
+  ///
+  /// Returns a string with the format: "\(name):\(id)"
+  public var description: String {
+    return "\(name):\(id)"
+  }
+}

--- a/Sources/Protocols/Uniquable.swift
+++ b/Sources/Protocols/Uniquable.swift
@@ -1,0 +1,32 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// A protocol that provides a unique identifier for an object using a UUID.
+///
+/// `Uniquable` extends `Identifiable` to specifically use a UUID as the identifier type.
+/// This provides a standardized approach to unique identification, ensuring compatibility with
+/// Foundation's UUID type.
+///
+/// ```swift
+/// struct User: Uniquable {
+///   let id = UUID()
+///   let name: String
+/// }
+///
+/// let user = User(name: "Alex")
+/// print(user.id) // Prints the UUID
+/// ```
+///
+/// - Note: Types conforming to `Uniquable` automatically conform to `Identifiable`,
+///   making them compatible with SwiftUI and other frameworks that leverage the
+///   `Identifiable` protocol.
+public protocol Uniquable: Identifiable {
+  /// A unique identifier for the instance.
+  ///
+  /// This property distinguishes one instance from all other instances.
+  var id: UUID { get }
+}

--- a/Tests/ProtocolTests/Describable.swift
+++ b/Tests/ProtocolTests/Describable.swift
@@ -1,0 +1,30 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import Obsidian
+
+@Suite("Obsidian/Protocols: Describable")
+struct DescribableTests {
+  
+  // Test structure that conforms to Describable
+  struct TestDescribable: Describable {
+    let description: String
+  }
+  
+  @Test("Describable provides description")
+  func describable_provides_description() throws {
+    // Given
+    let test_value = "Test"
+    let describable = TestDescribable(description: test_value)
+    
+    // When
+    let description = describable.description
+    
+    // Then
+    #expect(description == test_value)
+  }
+}

--- a/Tests/ProtocolTests/Namable.swift
+++ b/Tests/ProtocolTests/Namable.swift
@@ -1,0 +1,78 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import Obsidian
+
+@Suite("Obsidian/Protocols: Namable")
+struct NamableTests {
+  
+  // Basic test structure using default implementation
+  struct DefaultNamable: Namable {}
+  
+  // Test structure with custom name implementation
+  struct CustomNamable: Namable {
+    let name: String
+  }
+  
+  // Generic test structure to verify generic type name handling
+  struct GenericNamable<T>: Namable {
+    let value: T
+  }
+  
+  @Test("Default implementation returns type name")
+  func default_implementation_returns_type_name() throws {
+    // Given
+    let namable = DefaultNamable()
+    
+    // When
+    let name = namable.name
+    
+    // Then
+    #expect(name == "DefaultNamable")
+  }
+  
+  @Test("Custom implementation returns provided name")
+  func custom_implementation_returns_provided_name() throws {
+    // Given
+    let custom_name = "Custom Name"
+    let namable = CustomNamable(name: custom_name)
+    
+    // When
+    let name = namable.name
+    
+    // Then
+    #expect(name == custom_name)
+  }
+  
+  @Test("Generic type names include type parameters")
+  func generic_type_names_include_parameters() throws {
+    // Given
+    let namable = GenericNamable(value: "String Value")
+    
+    // When
+    let name = namable.name
+    
+    // Then
+    #expect(name == "GenericNamable<String>")
+  }
+  
+  @Test("Default implementation does not include parentheses")
+  func default_implementation_excludes_parentheses() throws {
+    // Given
+    let namable = DefaultNamable()
+    
+    // When
+    let name = namable.name
+    let description = String(describing: namable)
+    
+    // Then
+    #expect(!name.contains("("))
+    #expect(!name.contains(")"))
+    #expect(description.contains("("))
+    #expect(description.contains(")"))
+  }
+}

--- a/Tests/ProtocolTests/Representable.swift
+++ b/Tests/ProtocolTests/Representable.swift
@@ -1,0 +1,98 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import Obsidian
+
+@Suite("Obsidian/Protocols: Representable")
+struct RepresentableTests {
+  
+  // Basic test structure with minimal implementation
+  struct DefaultRepresentable: Representable {
+    let id = UUID()
+    // Uses default implementations for name and description
+  }
+  
+  // Test structure with custom name
+  struct CustomNameRepresentable: Representable {
+    let id = UUID()
+    let name: String
+    // Uses default implementation for description
+  }
+  
+  // Test structure with custom description
+  struct CustomDescriptionRepresentable: Representable {
+    let id = UUID()
+    let description: String
+    // Uses default implementation for name
+  }
+  
+  @Test("Representable conforms to Uniquable")
+  func representable_conforms_to_uniquable() throws {
+    // Given
+    let is_uniquable = (DefaultRepresentable.self as Any) is any Uniquable.Type
+    
+    // Then
+    #expect(is_uniquable)
+  }
+  
+  @Test("Representable conforms to Namable")
+  func representable_conforms_to_namable() throws {
+    // Given
+    let is_namable = (DefaultRepresentable.self as Any) is any Namable.Type
+    
+    // Then
+    #expect(is_namable)
+  }
+  
+  @Test("Representable conforms to Describable")
+  func representable_conforms_to_describable() throws {
+    // Given
+    let is_describable = (DefaultRepresentable.self as Any) is any Describable.Type
+    
+    // Then
+    #expect(is_describable)
+  }
+  
+  @Test("Default description combines name and id")
+  func default_description_combines_name_and_id() throws {
+    // Given
+    let representable = DefaultRepresentable()
+    
+    // When
+    let description = representable.description
+    
+    // Then
+    #expect(description == "\(representable.name):\(representable.id)")
+  }
+  
+  @Test("Default description works with custom name")
+  func default_description_works_with_custom_name() throws {
+    // Given
+    let custom_name = "Custom Name"
+    let representable = CustomNameRepresentable(name: custom_name)
+    
+    // When
+    let description = representable.description
+    
+    // Then
+    #expect(description == "\(custom_name):\(representable.id)")
+  }
+  
+  @Test("Custom description overrides default implementation")
+  func custom_description_overrides_default() throws {
+    // Given
+    let custom_description = "Custom Description"
+    let representable = CustomDescriptionRepresentable(description: custom_description)
+    
+    // When
+    let description = representable.description
+    
+    // Then
+    #expect(description == custom_description)
+    #expect(description != "\(representable.name):\(representable.id)")
+  }
+}

--- a/Tests/ProtocolTests/Uniquable.swift
+++ b/Tests/ProtocolTests/Uniquable.swift
@@ -1,0 +1,53 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import Obsidian
+
+@Suite("Obsidian/Protocols: Uniquable")
+struct UniquableTests {
+  
+  // Test structure that conforms to Uniquable
+  struct TestUniquable: Uniquable {
+    let id = UUID()
+    let value: String
+  }
+  
+  @Test("Uniquable conforms to Identifiable")
+  func uniquable_conforms_to_identifiable() throws {
+    // Given
+    let is_identifiable = (TestUniquable.self as Any) is any Identifiable.Type
+    
+    // Then
+    #expect(is_identifiable)
+  }
+  
+  @Test("Uniquable provides UUID identifier")
+  func uniquable_provides_uuid_identifier() throws {
+    // Given
+    let uniquable = TestUniquable(value: "Test")
+    
+    // When
+    let id = uniquable.id
+    
+    // Then
+    #expect(type(of: id) == type(of: UUID()))
+  }
+  
+  @Test("Different Uniquable instances have different IDs")
+  func uniquable_instances_have_different_ids() throws {
+    // Given
+    let uniquable1 = TestUniquable(value: "Test 1")
+    let uniquable2 = TestUniquable(value: "Test 2")
+    
+    // When
+    let id1 = uniquable1.id
+    let id2 = uniquable2.id
+    
+    // Then
+    #expect(id1 != id2)
+  }
+}


### PR DESCRIPTION
Directly migrated from [Sable](https://github.com/beeauvin/Sable). This forces specifying a minimum macOS version in the package (Identifiable).