### PR TITLE
feat(package): specify minimum ios version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
   name: "Obsidian",
   platforms: [
     .macOS(.v10_15),
+    .iOS(.v12),
   ],
   products: [
     .library(name: "Obsidian", targets: ["Obsidian"]),


### PR DESCRIPTION
Setting this in hopes that the compiler will catch issues and fail to build if using features unavailable to the platform like it does for macOS. Maybe SPI will help catch issues. Not really able to run automated tests against iOS though sooo.... 🤷🏻‍♀️