### PR TITLE
feat(foundation): catching result extension

### DIFF
--- a/Sources/Foundation/Result/ResultCatching.swift
+++ b/Sources/Foundation/Result/ResultCatching.swift
@@ -1,0 +1,68 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+public extension Result where Failure == Error {
+  
+  // MARK: - Catching
+  
+  /// Creates a Result by running the provided throwing closure, capturing either a success or an error.
+  ///
+  /// This method is similar to the built-in `Result.init(catching:)` initializer but
+  /// provides a consistent interface with Obsidian's other catching functions.
+  ///
+  /// ```swift
+  /// // Convert a throwing function call into a Result
+  /// let result = Result<Data, Error>.catching {
+  ///   try file_manager.contents(atPath: path)
+  /// }
+  ///
+  /// // Chain with other Result extensions
+  /// let text = Result<Data, Error>.catching {
+  ///   try file_manager.contents(atPath: path)
+  /// }.transform { data in
+  ///   String(data: data, encoding: .utf8)
+  /// }.otherwise("Empty file")
+  /// ```
+  ///
+  /// - Parameter body: A throwing closure to execute
+  /// - Returns: A Result containing either the value returned by the closure or the thrown error
+  static func catching(_ body: () throws -> Success) -> Result<Success, Failure> {
+    do {
+      return .success(try body())
+    } catch {
+      return .failure(error)
+    }
+  }
+  
+  // MARK: - Async Catching
+  
+  /// Creates a Result by running the provided async throwing closure, capturing either a success or an error.
+  ///
+  /// This method provides an async variant of `catching(_:)` for use with Swift's structured concurrency.
+  ///
+  /// ```swift
+  /// // Convert an async throwing function call into a Result
+  /// let result = await Result<Data, Error>.catching {
+  ///   try await network_service.fetch_data(from: url)
+  /// }
+  ///
+  /// // Chain with other Result extensions
+  /// let text = await Result<Data, Error>.catching {
+  ///   try await network_service.fetch_data(from: url)
+  /// }.transform { data in
+  ///   String(data: data, encoding: .utf8)
+  /// }.otherwise("No data available")
+  /// ```
+  ///
+  /// - Parameter body: An async throwing closure to execute
+  /// - Returns: A Result containing either the value returned by the closure or the thrown error
+  static func catching(_ body: () async throws -> Success) async -> Result<Success, Failure> {
+    do {
+      return .success(try await body())
+    } catch {
+      return .failure(error)
+    }
+  }
+}

--- a/Tests/FoundationTests/Result/ResultCatchingTests.swift
+++ b/Tests/FoundationTests/Result/ResultCatchingTests.swift
@@ -1,0 +1,98 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import Obsidian
+
+@Suite("Obsidian/Foundation/Result: Catching")
+struct ResultCatchingTests {
+  // Custom error type for testing
+  enum TestError: Error, Equatable {
+    case expected
+    case other
+  }
+  
+  // Test helpers
+  private func success_function() throws -> String {
+    return "Success"
+  }
+  
+  private func failure_function() throws -> String {
+    throw TestError.expected
+  }
+  
+  private func async_success_function() async throws -> Int {
+    return 42
+  }
+  
+  private func async_failure_function() async throws -> Int {
+    throw TestError.expected
+  }
+  
+  // MARK: - Catching Tests
+  
+  @Test("catching(_:) returns success when no error thrown")
+  func catching_returns_success_when_no_error_thrown() throws {
+    // When
+    let result = Result<String, Error>.catching {
+      try success_function()
+    }
+    
+    // Then
+    if case .success(let value) = result {
+      #expect(value == "Success")
+    } else {
+      #expect(Bool(false), "Expected success, got failure")
+    }
+  }
+  
+  @Test("catching(_:) returns failure when error thrown")
+  func catching_returns_failure_when_error_thrown() throws {
+    // When
+    let result = Result<String, Error>.catching {
+      try failure_function()
+    }
+    
+    // Then
+    if case .failure(let error) = result {
+      #expect(error as? TestError == .expected)
+    } else {
+      #expect(Bool(false), "Expected failure, got success")
+    }
+  }
+  
+  // MARK: - Async Catching Tests
+  
+  @Test("catching(_:) with async returns success when no error thrown")
+  func catching_async_returns_success_when_no_error_thrown() async throws {
+    // When
+    let result = await Result<Int, Error>.catching {
+      try await async_success_function()
+    }
+    
+    // Then
+    if case .success(let value) = result {
+      #expect(value == 42)
+    } else {
+      #expect(Bool(false), "Expected success, got failure")
+    }
+  }
+  
+  @Test("catching(_:) with async returns failure when error thrown")
+  func catching_async_returns_failure_when_error_thrown() async throws {
+    // When
+    let result = await Result<Int, Error>.catching {
+      try await async_failure_function()
+    }
+    
+    // Then
+    if case .failure(let error) = result {
+      #expect(error as? TestError == .expected)
+    } else {
+      #expect(Bool(false), "Expected failure, got success")
+    }
+  }
+}


### PR DESCRIPTION
Functionally equivalent to Result(catching: ...) but has async support. Radical.