### PR TITLE
feat(foundation): void success result extension

### DIFF
--- a/Sources/Foundation/Result/ResultSuccess.swift
+++ b/Sources/Foundation/Result/ResultSuccess.swift
@@ -1,0 +1,25 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+public extension Result where Success == Void {
+  
+  // MARK: - Success
+  
+  /// A convenience property that returns a successful Result with a Void value.
+  ///
+  /// This property provides a more natural way to create a successful Result
+  /// when the success type is Void, avoiding the awkward `.success(())` syntax.
+  ///
+  /// ```swift
+  /// // Instead of:
+  /// let result: Result<Void, Error> = .success(())
+  ///
+  /// // Use:
+  /// let result: Result<Void, Error> = .success
+  /// ```
+  ///
+  /// - Returns: A Result in the success state with a Void value
+  static var success: Self { .success(()) }
+}

--- a/Tests/FoundationTests/Result/ResultSuccessTests.swift
+++ b/Tests/FoundationTests/Result/ResultSuccessTests.swift
@@ -1,0 +1,34 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import Obsidian
+
+@Suite("Obsidian/Foundation/Result: Success")
+struct ResultSuccessTests {
+  // Custom error type for testing
+  enum TestError: Error, Equatable {
+    case expected
+  }
+  
+  // MARK: - Static Success Tests
+  
+  @Test("success returns a success result with void value")
+  func success_returns_success_result_with_void_value() throws {
+    // Given
+    let result: Result<Void, TestError> = .success
+    
+    // When
+    // Nothing to do here, just test the value
+    
+    // Then
+    if case .success = result {
+      #expect(Bool(true)) // Success case confirmed
+    } else {
+      #expect(Bool(false), "Expected success, got failure")
+    }
+  }
+}


### PR DESCRIPTION
Basically writing `.success(())` is gross and I hate it so this fixes that. Yay.