### PR TITLE
deps(dependabot): swift

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@
 
 version: 2
 updates:
+  - package-ecosystem: swift
+    open-pull-requests-limit: 10
+    directory: /
+    schedule:
+      interval: weekly
+    assignees:
+      - beeauvin
   - package-ecosystem: github-actions
     open-pull-requests-limit: 10
     directory: /


### PR DESCRIPTION
Obsidian doesn't have any package dependencies bit this feels like it's good to have as a default config just in case. I was adding it to Sable anyway. ^^