### PR TITLE
feat(flow): migrate sable to obsidian

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
     .library(name: "Obsidian", targets: ["Obsidian"]),
     .library(name: "ObsidianCore", targets: ["ObsidianCore"]),
     .library(name: "ObsidianFoundation", targets: ["ObsidianFoundation"]),
+    .library(name: "ObsidianFlow", targets: ["ObsidianFlow"]),
   ],
   targets: [
     .target(name: "Obsidian", dependencies: [
@@ -28,5 +29,8 @@ let package = Package(
     
     .target(name: "ObsidianFoundation", dependencies: ["ObsidianCore"], path: "Sources/Foundation"),
     .testTarget(name: "ObsidianFoundationTests", dependencies: ["ObsidianFoundation"], path: "Tests/Foundation"),
+
+    .target(name: "ObsidianFlow", dependencies: ["ObsidianCore", "ObsidianFoundation"], path: "Sources/Flow"),
+    .testTarget(name: "ObsidianFlowTests", dependencies: ["Obsidian", "ObsidianFlow"], path: "Tests/Flow"),
   ]
 )

--- a/Sources/Flow/Channel/Channel.swift
+++ b/Sources/Flow/Channel/Channel.swift
@@ -1,0 +1,80 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A typed message handler that delivers pulses to a registered handler function.
+///
+/// `Channel` provides a safe mechanism for delivering strongly-typed pulse messages
+/// to registered handlers. It maintains high performance for message delivery operations
+/// while ensuring thread safety through task-based concurrency.
+///
+/// Channels use a fire-and-forget model for pulse delivery, spawning tasks that
+/// inherit the priority of the pulse being processed. This approach ensures that
+/// channel operations remain non-blocking while maintaining appropriate prioritization.
+///
+/// ```swift
+/// // Create a channel with a handler
+/// let auth_channel = Channel { pulse in
+///   await process_auth_event(pulse.data)
+/// }
+///
+/// // Send pulses through the channel
+/// auth_channel.send(login_pulse)
+/// ```
+///
+/// ## Lifecycle Considerations
+///
+/// Channel lifecycle is managed through Swift's automatic reference counting. The
+/// channel maintains a strong reference to its handler function, which means:
+///
+/// - The handler will remain alive as long as the channel exists
+/// - Components referenced by the handler will not be deallocated until the channel is released
+/// - Channels are ideal for long-lived services or components with coupled lifetimes
+/// - For more complex lifecycle management, consider using `Stream` instead
+///
+/// This design makes channels perfect for simple, persistent message routing but
+/// requires careful consideration when used with temporary or one-off handlers.
+public struct Channel<Data: Pulsable>: Channeling, Sendable {
+  /// The handler function that processes pulses sent to this channel
+  private let handler: ChannelHandler<Data>
+
+  /// Creates a new channel with the specified handler function.
+  ///
+  /// The channel will process all pulses sent to it using the provided handler,
+  /// executing each handler call in a separate task that inherits the pulse's
+  /// priority level.
+  ///
+  /// ```swift
+  /// let event_channel = Channel { pulse in
+  ///   await event_processor.handle(pulse.data)
+  /// }
+  /// ```
+  ///
+  /// - Parameter handler: The function that will process pulses sent to this channel
+  public init(handler: @escaping ChannelHandler<Data>) {
+    self.handler = handler
+  }
+
+  /// Sends a pulse to this channel for processing.
+  ///
+  /// This method delivers the provided pulse to the channel's registered handler
+  /// function. Delivery happens asynchronously in a separate task that inherits
+  /// the priority of the pulse, ensuring that high-priority pulses are processed
+  /// appropriately.
+  ///
+  /// ```swift
+  /// channel.send(login_pulse)
+  /// ```
+  ///
+  /// The channel guarantees that the pulse will be delivered to the handler,
+  /// with the handler executing asynchronously to maintain non-blocking behavior.
+  /// Multiple threads can safely call this method concurrently.
+  ///
+  /// - Parameter pulse: The typed pulse to send to this channel
+  public func send(_ pulse: Pulse<Data>) {
+    Task(priority: pulse.priority) {
+      await handler(pulse)
+    }
+  }
+}

--- a/Sources/Flow/Channel/Protocols/Channeling.swift
+++ b/Sources/Flow/Channel/Protocols/Channeling.swift
@@ -1,0 +1,43 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A protocol that defines the core operations for channel-like components.
+///
+/// `Channeling` standardizes the interface for any component that provides
+/// channel-like functionality, whether directly implementing a channel or
+/// wrapping one. This allows for consistent usage patterns and enables
+/// composition and delegation without tight coupling to the concrete `Channel` type.
+///
+/// The protocol focuses on the essential operation of message delivery:
+/// - Send a strongly-typed pulse to a handler
+///
+/// Lifecycle management is handled through Swift's standard reference counting,
+/// making the interface simple and predictable.
+///
+/// ```swift
+/// struct ChannelWrapper<Data: Pulsable>: Channeling {
+///   private let inner_channel: Channel<Data>
+///
+///   init(handler: @escaping ChannelHandler<Data>) {
+///     self.inner_channel = Channel(handler: handler)
+///   }
+///
+///   func send(_ pulse: Pulse<Data>) async {
+///     await inner_channel.send(pulse)
+///   }
+/// }
+/// ```
+///
+/// This protocol enables building more complex channel-based architectures
+/// through composition and wrapping, while maintaining a consistent interface.
+public protocol Channeling<Data> {
+  /// The type of data this channel can handle
+  associatedtype Data: Pulsable
+  
+  /// Sends a pulse to this channel for processing.
+  ///
+  /// - Parameter pulse: The typed pulse to send through this channel
+  func send(_ pulse: Pulse<Data>)
+}

--- a/Sources/Flow/Channel/Types/ChannelHandler.swift
+++ b/Sources/Flow/Channel/Types/ChannelHandler.swift
@@ -1,0 +1,33 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Type alias that defines a handler function for processing pulses within a channel.
+///
+/// `ChannelHandler` represents an asynchronous function that consumes pulses through
+/// a channel. Each handler:
+/// - Takes a strongly-typed pulse as input
+/// - Executes asynchronously to ensure non-blocking operations
+/// - Returns nothing (Void), focusing exclusively on processing the pulse
+/// - Conforms to Sendable to enable safe concurrent execution across actor boundaries
+///
+/// Channel handlers are designed to be registered with a channel to process all
+/// pulses sent through that specific channel. They act as the terminal processor in a
+/// pulse's journey through the messaging system.
+///
+/// ```swift
+/// // Define a simple handler that logs pulse information
+/// let logging_handler: ChannelHandler<LoginEvent> = { pulse in
+///   await logger.log("Received login event: \(pulse.data.user_id)")
+/// }
+///
+/// // Define a handler that forwards pulses to another system
+/// let forwarding_handler: ChannelHandler<SystemEvent> = { pulse in
+///   await external_system.process(pulse)
+/// }
+/// ```
+///
+/// Handlers automatically inherit the priority of the pulse being processed,
+/// ensuring that high-priority pulses receive appropriately prioritized handling.
+public typealias ChannelHandler<Data: Pulsable> = @Sendable (Pulse<Data>) async -> Void

--- a/Sources/Flow/Pulse/Extensions/Pulse/FluentBuilder.swift
+++ b/Sources/Flow/Pulse/Extensions/Pulse/FluentBuilder.swift
@@ -1,0 +1,135 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// Extension providing a fluent builder API for Pulse instances.
+///
+/// These methods enable modification of Pulse properties through a natural language
+/// interface while maintaining immutability. Each method returns a new Pulse instance
+/// with the desired modifications, preserving the original's identity information.
+///
+/// Use these methods to create rich, contextual pulses through method chaining:
+///
+/// ```swift
+/// let enhanced_pulse = Pulse(login_event)
+///   .debug()
+///   .priority(.high)
+///   .tagged("auth", "security")
+///   .from(auth_service)
+/// ```
+///
+/// The fluent API follows Obsidian's core design principles of natural language interfaces,
+/// strong type safety, and immutability for thread safety.
+extension Pulse {
+  /// Marks this pulse as a debug pulse for logging and tracing
+  ///
+  /// Debug pulses may receive special handling:
+  /// - Additional logging and tracing
+  /// - Inclusion in debug visualizations
+  /// - Heightened verbosity in error contexts
+  ///
+  /// ```swift
+  /// let pulse = Pulse(event).debug() // Defaults to true
+  /// let regular_pulse = debug_pulse.debug(false) // Disable debugging
+  /// ```
+  public func debug(_ enabled: Bool = true) -> Pulse<Data> {
+    return fluently(meta: meta.fluently(debug: enabled))
+  }
+  
+  /// Establishes a causal relationship with another pulse
+  ///
+  /// This both copies the trace ID from the original pulse and sets
+  /// the `echoes` reference, maintaining the complete causal chain.
+  ///
+  /// Use this when a pulse is emitted as a direct result of processing
+  /// another pulse, establishing a clear cause-and-effect relationship.
+  ///
+  /// ```swift
+  /// // Create a response that maintains the trace
+  /// let response = Pulse(completion_event).echoes(original_pulse)
+  /// ```
+  public func echoes<T: Pulsable>(_ pulse: Pulse<T>) -> Pulse<Data> {
+    return fluently(meta: meta.fluently(
+      trace: pulse.meta.trace,
+      echoes: PulseSource.From(source: pulse)
+    ))
+  }
+  
+  /// Sets the source of this pulse
+  ///
+  /// The source identifies the component or system that created this pulse.
+  /// This provides context for debugging and tracing message flows.
+  ///
+  /// ```swift
+  /// let pulse = Pulse(event).from(auth_service)
+  /// ```
+  ///
+  /// Typically set automatically by the `PulseEmitter`, but can be
+  /// manually specified when needed.
+  public func from(_ representable: any Representable) -> Pulse<Data> {
+    return fluently(meta: meta.fluently(source: PulseSource.From(source: representable)))
+  }
+  
+  /// Sets the processing priority of this pulse
+  ///
+  /// Higher-priority pulses are processed before lower-priority ones
+  /// when resources are constrained.
+  ///
+  /// ```swift
+  /// let critical_pulse = Pulse(event).priority(.high)
+  /// let background_pulse = Pulse(stats_event).priority(.low)
+  /// ```
+  public func priority(_ priority: TaskPriority) -> Pulse<Data> {
+    return fluently(meta: meta.fluently(priority: priority))
+  }
+  
+  /// Adds tags to this pulse for filtering and routing
+  ///
+  /// Tags provide a lightweight extension mechanism for pulse metadata.
+  /// Multiple tags can be added to create rich categorization.
+  ///
+  /// By default, this method adds the specified tags to any existing tags.
+  /// Set `reset` to true to replace all existing tags with the new ones.
+  ///
+  /// ```swift
+  /// // Add tags to existing ones
+  /// let pulse = Pulse(event).tagged("auth", "security-audit")
+  ///
+  /// // Replace all existing tags
+  /// let pulse = Pulse(event).tagged("new-tag", reset: true)
+  /// ```
+  public func tagged(_ tags: String..., reset: Bool = false) -> Pulse<Data> {
+    var updated_tags = reset ? [] : meta.tags
+    tags.forEach { updated_tags.insert($0) }
+    
+    return fluently(meta: meta.fluently(tags: updated_tags))
+  }
+  
+  /// Adopts all metadata from another pulse
+  ///
+  /// This method copies the complete metadata from the provided pulse while
+  /// preserving the current pulse's identity and data. Use it when you want
+  /// to create a pulse with identical operational characteristics to another.
+  ///
+  /// ```swift
+  /// // Create a new pulse with the same metadata as an existing one
+  /// let template_pulse = retrieve_template_pulse()
+  /// let new_pulse = Pulse(event_data).like(template_pulse)
+  /// ```
+  ///
+  /// All metadata properties are copied, including:
+  /// - Debug status
+  /// - Trace ID
+  /// - Source information
+  /// - Echoed pulse references
+  /// - Priority level
+  /// - Tags
+  ///
+  /// The original pulse's identity (ID and timestamp) and data are preserved.
+  public func like<T: Pulsable>(_ pulse: Pulse<T>) -> Pulse<Data> {
+    return fluently(meta: pulse.meta)
+  }
+}

--- a/Sources/Flow/Pulse/Extensions/Pulse/PulseFluently.swift
+++ b/Sources/Flow/Pulse/Extensions/Pulse/PulseFluently.swift
@@ -1,0 +1,76 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianCore
+
+/// Internal extension providing fluent builder pattern support for Pulse instances.
+///
+/// This extension enables convenient modification of Pulse instances through a fluent interface,
+/// making it easier to create derived Pulses while preserving core identity information.
+/// The methods maintain immutability by creating new instances rather than modifying existing ones.
+internal extension Pulse {
+  /// Creates a new Pulse instance with selectively updated properties.
+  ///
+  /// This static factory method enables the fluent builder pattern by constructing
+  /// a new Pulse that preserves the identity (id and timestamp) of the original
+  /// while optionally updating the data payload and/or metadata.
+  ///
+  /// ```swift
+  /// // Create a new pulse with updated metadata but same data
+  /// let updated_pulse = Pulse.Fluently(original_pulse, meta: new_meta)
+  ///
+  /// // Create a new pulse with updated data but same metadata
+  /// let transformed_pulse = Pulse.Fluently(original_pulse, data: new_data)
+  ///
+  /// // Create a new pulse with both updated data and metadata
+  /// let complete_update = Pulse.Fluently(original_pulse, data: new_data, meta: new_meta)
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - pulse: The original Pulse instance whose identity will be preserved
+  ///   - data: Optional new data payload (defaults to nil, which retains original data)
+  ///   - meta: Optional new metadata (defaults to nil, which retains original metadata)
+  /// - Returns: A new Pulse instance with the same identity but potentially updated components
+  static func Fluently(
+    _ pulse: Pulse<Data>,
+    data: Optional<Data> = .none,
+    meta: Optional<PulseMeta> = .none
+  ) -> Pulse<Data> {
+    return Pulse(
+      id: pulse.id,
+      timestamp: pulse.timestamp,
+      data: data.otherwise(pulse.data),
+      meta: meta.otherwise(pulse.meta)
+    )
+  }
+  
+  /// Creates a new Pulse with selectively updated properties using the fluent pattern.
+  ///
+  /// This instance method provides a more natural interface for the fluent builder pattern,
+  /// allowing callsite code to create modified versions of a Pulse through method chaining.
+  /// It preserves the identity of the original Pulse while allowing updates to data and metadata.
+  ///
+  /// ```swift
+  /// // Create a simple update with new metadata
+  /// let debug_pulse = original_pulse.fluently(meta: debug_meta)
+  ///
+  /// // Chain multiple fluent operations
+  /// let final_pulse = original_pulse
+  ///   .debug(true)                // Uses fluently internally
+  ///   .priority(.high)            // Uses fluently internally
+  ///   .tagged("auth", "critical") // Uses fluently internally
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - data: Optional new data payload (defaults to nil, which retains original data)
+  ///   - meta: Optional new metadata (defaults to nil, which retains original metadata)
+  /// - Returns: A new Pulse instance with the same identity but potentially updated components
+  func fluently(
+    data: Optional<Data> = .none,
+    meta: Optional<PulseMeta> = .none
+  ) -> Pulse<Data> {
+    return Pulse.Fluently(self, data: data, meta: meta)
+  }
+}

--- a/Sources/Flow/Pulse/Extensions/Pulse/Respond.swift
+++ b/Sources/Flow/Pulse/Extensions/Pulse/Respond.swift
@@ -1,0 +1,55 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// Extension providing a static factory method for creating response pulses.
+///
+/// This extension adds a dedicated method for creating pulses that respond to
+/// other pulses, maintaining causal chains and trace information while providing
+/// a natural language interface.
+extension Pulse {
+  /// Creates a new pulse that responds to another pulse.
+  ///
+  /// This factory method creates a response pulse that:
+  /// - Maintains the same trace ID as the original pulse
+  /// - Sets the original pulse as the one being echoed
+  /// - Optionally sets a new source component
+  /// - Creates a new pulse ID and timestamp
+  ///
+  /// ```swift
+  /// // Create a simple response
+  /// let response = Pulse.Respond(to: original_pulse, with: completion_data)
+  ///
+  /// // Create a response with a specific source
+  /// let response = Pulse.Respond(to: original_pulse, with: result_data, from: processing_service)
+  /// ```
+  ///
+  /// Use this method when handling a pulse and generating a direct response
+  /// to preserve the causal relationship and contextual information needed
+  /// for tracing and debugging.
+  ///
+  /// - Parameters:
+  ///   - original: The pulse being responded to
+  ///   - data: The data payload for the response pulse
+  ///   - source: Optional source for the response (if nil, no source is set)
+  /// - Returns: A new pulse that echoes the original pulse
+  public static func Respond<Original: Pulsable>(
+    to original: Pulse<Original>,
+    with data: Data,
+    from source: Optional<any Representable> = .none
+  ) -> Pulse<Data> {
+    // Create a new pulse with the provided data
+    let pulse = Pulse(data).echoes(original)
+    
+    // If a source was provided, set it in the metadata
+    if let source = source {
+      return pulse.from(source)
+    }
+    
+    // Return a new pulse with the updated metadata
+    return pulse
+  }
+}

--- a/Sources/Flow/Pulse/Extensions/PulseMeta/MetaFluently.swift
+++ b/Sources/Flow/Pulse/Extensions/PulseMeta/MetaFluently.swift
@@ -1,0 +1,92 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianCore
+import ObsidianFoundation
+
+/// Extension to `PulseMeta` providing fluent modification capabilities.
+///
+/// These methods enable immutable transformation of `PulseMeta` instances
+/// through a natural language fluent interface. The design maintains
+/// immutability while allowing for property updates, which aligns with
+/// Obsidian's design principle of thread safety in actor-based environments.
+///
+/// Fluent builders are primarily used internally by the `Pulse` type to
+/// implement its own public fluent interface, though they may be used
+/// directly when creating custom metadata handling.
+///
+/// ```swift
+/// // Example of internal usage through Pulse's fluent interface
+/// let enhanced_pulse = original_pulse
+///   .debug(true)
+///   .priority(.high)
+///   .tagged("critical", "auth")
+/// ```
+internal extension PulseMeta {
+  /// Creates a new PulseMeta instance with updated properties.
+  ///
+  /// Used internally by the fluent builders on `Pulse` to maintain immutability
+  /// while allowing property updates.
+  ///
+  /// - Parameters:
+  ///   - original: The source PulseMeta instance to copy values from
+  ///   - debug: Whether this pulse is in debug mode
+  ///   - trace: A unique identifier for tracing this pulse
+  ///   - source: The component that generated this pulse
+  ///   - echoes: The pulse that caused or preceded this one
+  ///   - priority: The processing priority for this pulse
+  ///   - tags: A set of string tags for filtering and categorization
+  /// - Returns: A new PulseMeta instance with the specified properties updated
+  static func Fluently(
+    _ original: PulseMeta,
+    debug: Optional<Bool> = .none,
+    trace: Optional<UUID> = .none,
+    source: Optional<PulseSource> = .none,
+    echoes: Optional<PulseSource> = .none,
+    priority: Optional<TaskPriority> = .none,
+    tags: Optional<Set<String>> = .none
+  ) -> PulseMeta {
+    return PulseMeta(
+      debug: debug.otherwise(original.debug),
+      trace: trace.otherwise(original.trace),
+      source: source.optionally(original.source),
+      echoes: echoes.optionally(original.echoes),
+      priority: priority.otherwise(TaskPriority(rawValue: original.priority)),
+      tags: tags.otherwise(original.tags)
+    )
+  }
+  
+  /// Creates a new PulseMeta instance with updated properties.
+  ///
+  /// This instance method provides a more ergonomic way to use the fluent pattern,
+  /// automatically passing the current instance to the static Fluently method.
+  ///
+  /// - Parameters:
+  ///   - debug: Whether this pulse is in debug mode
+  ///   - trace: A unique identifier for tracing this pulse
+  ///   - source: The component that generated this pulse
+  ///   - echoes: The pulse that caused or preceded this one
+  ///   - priority: The processing priority for this pulse
+  ///   - tags: A set of string tags for filtering and categorization
+  /// - Returns: A new PulseMeta instance with the specified properties updated
+  func fluently(
+    debug: Optional<Bool> = .none,
+    trace: Optional<UUID> = .none,
+    source: Optional<PulseSource> = .none,
+    echoes: Optional<PulseSource> = .none,
+    priority: Optional<TaskPriority> = .none,
+    tags: Optional<Set<String>> = .none
+  ) -> PulseMeta {
+    return PulseMeta.Fluently(
+      self,
+      debug: debug,
+      trace: trace,
+      source: source,
+      echoes: echoes,
+      priority: priority,
+      tags: tags
+    )
+  }
+}

--- a/Sources/Flow/Pulse/Metadata/PulseMeta.swift
+++ b/Sources/Flow/Pulse/Metadata/PulseMeta.swift
@@ -1,0 +1,123 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// Metadata that provides operational context for a pulse message.
+///
+/// `PulseMeta` encapsulates system-level metadata about a pulse, including:
+/// - Debug status for development and testing
+/// - Tracing for message flow visualization
+/// - Source tracking for message origin
+/// - Echo tracking for causal relationships
+/// - Priority for task scheduling
+/// - Tags for filtering and categorization
+///
+/// This structure is primarily managed by the internal fluent builders on `Pulse`
+/// and is not typically created directly by end users.
+///
+/// The metadata travels with each pulse through the system, enabling:
+/// - Operational tracing for debugging complex message flows
+/// - Priority-based scheduling in async contexts
+/// - Causal chain tracking to understand message relationships
+/// - Filtering and routing based on tags
+///
+/// `PulseMeta` conforms to `Pulsable` to ensure it can safely traverse actor
+/// boundaries while maintaining type safety.
+@frozen public struct PulseMeta: Pulsable {
+  /// Indicates whether this pulse was created in debug mode.
+  ///
+  /// When true, the pulse may receive special handling:
+  /// - Additional logging and tracing
+  /// - Inclusion in debug visualizations
+  /// - Heightened verbosity in error contexts
+  ///
+  /// Debug pulses are particularly useful during development to track
+  /// specific message flows through complex systems.
+  public let debug: Bool
+  
+  /// A unique identifier for tracing this pulse through the system.
+  ///
+  /// The trace ID remains consistent across pulse transformations and can be used
+  /// to visualize a complete message flow. Multiple pulses may share the same
+  /// trace ID if they are part of the same logical operation or user interaction.
+  ///
+  /// This enables building comprehensive visualizations of message propagation
+  /// throughout a distributed system.
+  public let trace: UUID
+  
+  /// The system or component that generated this pulse.
+  ///
+  /// Captures the origin of a pulse, providing context about where the message
+  /// was created. This is essential for debugging and for understanding
+  /// message flow directionality.
+  ///
+  /// The source is typically generated automatically from the emitting actor
+  /// or component's identity information.
+  public let source: Optional<PulseSource>
+  
+  /// The pulse that caused or preceded this one.
+  ///
+  /// Establishes causal relationships between pulses, enabling the construction
+  /// of causal chains to understand how one message led to another.
+  ///
+  /// When a component processes a pulse and emits a new one in response,
+  /// the original pulse's identity is captured here to maintain the
+  /// relationship between cause and effect.
+  public let echoes: Optional<PulseSource>
+  
+  /// The scheduling priority of this pulse.
+  ///
+  /// Determines how urgently this pulse should be processed within
+  /// task scheduling systems. Higher priority pulses are processed
+  /// before lower priority ones when resources are constrained.
+  ///
+  /// Stored as a raw value to enable serialization, but accessors on
+  /// `Pulse` provide strongly-typed access via `TaskPriority`.
+  public let priority: TaskPriority.RawValue
+  
+  /// A set of string tags that provide a simple extension mechanism.
+  ///
+  /// Tags enable users to extend pulse functionality without modifying the
+  /// core structure. They serve multiple purposes:
+  /// - Feature flagging to enable or disable specific behaviors
+  /// - Custom routing based on application-specific concerns
+  /// - Contextual metadata that specific receivers might understand
+  /// - Application-level categorization beyond the core framework
+  ///
+  /// Since PulseMeta itself isn't directly extendable (at least until potential
+  /// future language features like union types), tags provide a lightweight way
+  /// for users to add their own metadata and build custom behaviors on top of
+  /// the messaging system.
+  public let tags: Set<String>
+  
+  /// Creates a new instance of pulse metadata with specified attributes.
+  ///
+  /// This initializer is internal as end users should not create `PulseMeta`
+  /// directly. Instead, they should use the fluent builders on `Pulse`.
+  ///
+  /// - Parameters:
+  ///   - debug: Whether this pulse is in debug mode
+  ///   - trace: A unique identifier for tracing this pulse
+  ///   - source: The component that generated this pulse
+  ///   - echoes: The pulse that caused or preceded this one
+  ///   - priority: The processing priority for this pulse
+  ///   - tags: A set of string tags for filtering and categorization
+  internal init(
+    debug: Bool = false,
+    trace: UUID = UUID(),
+    source: Optional<PulseSource> = .none,
+    echoes: Optional<PulseSource> = .none,
+    priority: TaskPriority = .medium,
+    tags: Set<String> = []
+  ) {
+    self.debug = debug
+    self.trace = trace
+    self.source = source
+    self.echoes = echoes
+    self.priority = priority.rawValue
+    self.tags = tags
+  }
+}

--- a/Sources/Flow/Pulse/Metadata/PulseSource.swift
+++ b/Sources/Flow/Pulse/Metadata/PulseSource.swift
@@ -1,0 +1,55 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// An internal structure that represents the origin of a pulse message.
+///
+/// `PulseSource` is used within the Obsidian system to track message provenance
+/// and causation chains. It appears in `PulseMeta` through the `source` and `echoes`
+/// properties, providing information about where pulses originated and what preceded them.
+///
+/// This type is not meant to be created directly by end users, but rather is managed
+/// internally by the Obsidian system. The `Pulsable` and `Representable` conformances
+/// ensure it can safely traverse actor boundaries and provide consistent identity information.
+@frozen public struct PulseSource: Pulsable, Representable {
+  /// A unique identifier for the pulse source.
+  public let id: UUID
+  
+  /// A human-readable name for the pulse source.
+  public let name: String
+  
+  /// Creates a `PulseSource` from any type that conforms to `Representable`.
+  ///
+  /// Used internally by the Obsidian system to track the origins of pulse messages.
+  ///
+  /// - Parameter source: A `Representable` object to create a source from
+  /// - Returns: A new `PulseSource` with the same identity and name as the source
+  internal static func From(source: any Representable) -> PulseSource {
+    return PulseSource(id: source.id, name: source.name)
+  }
+  
+  /// Creates a `PulseSource` from a pulse message.
+  ///
+  /// Used internally by the Obsidian system to track causation chains,
+  /// where one pulse causes another to be emitted.
+  ///
+  /// - Parameter pulse: A `Pulse` message to create a source from
+  /// - Returns: A new `PulseSource` with the same identity and name as the pulse
+  // internal static func From<Data: Pulsable>(pulse: Pulse<Data>) -> PulseSource {
+  //   return PulseSource(id: pulse.id, name: pulse.name)
+  // }
+  
+  /// Private initializer to ensure `PulseSource` instances are only created
+  /// through the internal factory methods.
+  ///
+  /// - Parameters:
+  ///   - id: A unique identifier for the source
+  ///   - name: A human-readable name for the source
+  private init(id: UUID, name: String) {
+    self.id = id
+    self.name = name
+  }
+}

--- a/Sources/Flow/Pulse/Protocols/Pulsable.swift
+++ b/Sources/Flow/Pulse/Protocols/Pulsable.swift
@@ -1,0 +1,33 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// A protocol that defines requirements for types that can be sent through the Pulse messaging system.
+///
+/// `Pulsable` combines several Swift protocol conformances to ensure that types can be:
+/// - Safely passed between threads and actors (`Sendable`)
+/// - Compared for equality (`Equatable`)
+/// - Duplicated as needed (`Copyable`)
+/// - Serialized and deserialized (`Codable`)
+/// - Used as dictionary keys or in sets (`Hashable`)
+///
+/// These requirements ensure that pulse messages can be safely transmitted across thread
+/// boundaries, cached, compared, persisted, and used in collections throughout the Obsidian framework.
+///
+/// ```swift
+/// struct UserLoggedIn: Pulsable {
+///   let user_id: UUID
+///   let timestamp: Date
+/// }
+///
+/// struct SettingsChanged: Pulsable {
+///   let settings: [String: Any]
+///   let changed_by: UUID
+/// }
+/// ```
+///
+/// - Note: By conforming to all these protocols, `Pulsable` types are guaranteed to work
+///   correctly within the actor-based messaging architecture of Obsidian. This enables
+///   compile-time safety for cross-thread communication.
+public protocol Pulsable: Sendable, Equatable, Copyable, Codable, Hashable {}

--- a/Sources/Flow/Pulse/Pulse.swift
+++ b/Sources/Flow/Pulse/Pulse.swift
@@ -1,0 +1,78 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// A lightweight, type-safe message container for async communication.
+///
+/// `Pulse` is the core message unit in the Obsidian system, encapsulating
+/// typed data along with metadata that provides operational context. Pulses
+/// can form causal chains to track related messages and maintain tracing
+/// information across the system.
+///
+/// Pulses are immutable, with all modifications creating new instances through
+/// the fluent builder pattern. This ensures thread safety when passing messages
+/// across actor boundaries.
+///
+/// Example usage:
+///
+/// ```swift
+/// // Create a simple pulse with default metadata
+/// let login_event = UserLoggedIn(user_id: user.id)
+/// let pulse = Pulse(login_event)
+///
+/// // Create a pulse with custom metadata
+/// let enhanced_pulse = pulse
+///   .priority(.high)
+///   .tagged("auth", "security")
+///   .from(auth_service)
+///
+/// // Create a response pulse that maintains causal chain
+/// let response_pulse = Pulse(AuthenticationCompleted(success: true))
+///   .echoes(enhanced_pulse)
+/// ```
+///
+/// `Pulse` conforms to both `Pulsable` and `Representable`, ensuring it can safely
+/// traverse actor boundaries and providing identity information for logging and debugging.
+@frozen public struct Pulse<Data: Pulsable>: Pulsable, Representable {
+  /// Unique identifier for tracking the pulse through the system
+  public let id: UUID
+  
+  /// Timestamp indicating when the pulse was created
+  public let timestamp: Date
+  
+  /// The strongly-typed data encapsulated by this pulse
+  public let data: Data
+  
+  /// Metadata providing system-level operational context
+  public let meta: PulseMeta
+  
+  /// A human-readable name for the pulse
+  public var name: String {
+    // Use type name for better readability in logs and debugging
+    return "Pulse:\(String(describing: type(of: data)))"
+  }
+  
+  /// Access to the priority as a strongly-typed value
+  public var priority: TaskPriority {
+    return TaskPriority(rawValue: meta.priority)
+  }
+  
+  /// Creates a new pulse with the provided data and default metadata
+  public init(_ data: Data) {
+    self.id = UUID()
+    self.timestamp = Date()
+    self.data = data
+    self.meta = PulseMeta()
+  }
+  
+  /// Private initializer used by the fluent builder pattern
+  internal init(id: UUID, timestamp: Date, data: Data, meta: PulseMeta) {
+    self.id = id
+    self.timestamp = timestamp
+    self.data = data
+    self.meta = meta
+  }
+}

--- a/Sources/Flow/Stream/Protocols/Streaming.swift
+++ b/Sources/Flow/Stream/Protocols/Streaming.swift
@@ -1,0 +1,62 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// A protocol that defines the core operations for stream-like components.
+///
+/// `Streaming` provides the interface for bidirectional communication pathways with
+/// explicit lifecycle management. Unlike the simpler `Channeling` protocol, streaming
+/// components support release operations and provide detailed result information about
+/// their state transitions.
+///
+/// Streams are designed for scenarios where:
+/// - Components need to be notified when connections are closed
+/// - Explicit lifecycle control is required
+/// - Error handling for connection state is important
+/// - Bidirectional awareness between endpoints is valuable
+///
+/// The protocol combines identity capabilities from `Representable` with messaging
+/// operations that return detailed results about success or failure states.
+///
+/// ```swift
+/// struct StreamWrapper<Data: Pulsable>: Streaming {
+///   private let inner_stream: Stream<Data>
+///
+///   var id: UUID { inner_stream.id }
+///   var name: String { "Wrapper:\(inner_stream.name)" }
+///
+///   init(handler: @escaping ChannelHandler<Data>) {
+///     self.inner_stream = Stream(handler: handler)
+///   }
+///
+///   func send(_ pulse: Pulse<Data>) async -> StreamResult {
+///     return await inner_stream.send(pulse)
+///   }
+///
+///   func release() async -> StreamResult {
+///     return await inner_stream.release()
+///   }
+/// }
+/// ```
+///
+/// This protocol enables building sophisticated stream-based architectures with
+/// predictable lifecycle management while maintaining compatibility through
+/// composition and delegation patterns.
+public protocol Streaming<Data>: Representable where Data: Pulsable {
+  /// The type of data this stream can handle
+  associatedtype Data: Pulsable
+  
+  /// Sends a pulse to this stream for processing.
+  ///
+  /// - Parameter pulse: The typed pulse to send through this stream
+  /// - Returns: A result indicating success or a specific stream error
+  func send(_ pulse: Pulse<Data>) async -> StreamResult
+  
+  /// Releases this stream, preventing further pulse processing.
+  ///
+  /// - Returns: A result indicating success or a specific stream error
+  func release() async -> StreamResult
+}

--- a/Sources/Flow/Stream/Pulses/StreamReleased.swift
+++ b/Sources/Flow/Stream/Pulses/StreamReleased.swift
@@ -1,0 +1,32 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianFoundation
+
+/// Represents a stream lifecycle event indicating that a stream has been released.
+///
+/// `StreamReleased` is a simple event type used internally by the `Stream` system to
+/// notify handlers when a stream endpoint has been released. It contains the stream's
+/// unique identifier, allowing for proper stream identification in multi-stream systems.
+///
+/// This type conforms to `Pulsable` to enable it to be sent through channels as part
+/// of the stream lifecycle notification system.
+///
+/// The stream identity is provided in two complementary ways:
+/// - Directly via the `stream_id` property for immediate access
+/// - Through pulse metadata as the source, accessible via `pulse.meta.source`
+///
+/// This dual approach provides both self-documentation and framework consistency.
+///
+/// Example usage within the Stream system:
+///
+/// ```swift
+/// // Send a stream released notification
+/// await notification_channel.send(Pulse(StreamReleased(stream_id: self.id)).from(self))
+/// ```
+@frozen public struct StreamReleased: Pulsable {
+  /// The unique identifier of the stream that was released
+  public let stream_id: UUID
+}

--- a/Sources/Flow/Stream/Stream.swift
+++ b/Sources/Flow/Stream/Stream.swift
@@ -1,0 +1,191 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import ObsidianCore
+import ObsidianFoundation
+
+/// A communication pathway with built-in bidirectional lifecycle awareness. Built on
+/// `Channel` primitives for high-performance message delivery.
+///
+/// `Stream` extends Obsidian's messaging architecture by providing a connection between
+/// components with mutual awareness of lifecycle events. Unlike a regular `Channel`,
+/// which offers simple fire-and-forget messaging, a `Stream` establishes a
+/// relationship where both ends can be notified when either side releases the connection.
+///
+/// Streams can be used directly through the Channeling interface:
+///
+/// ```swift
+/// // Create a stream with data and lifecycle handlers
+/// let resource_stream = Stream(
+///   source_released: { released_pulse in
+///     // Handle source closing the stream
+///     await resource_service.disconnect_source()
+///   },
+///   anchor_released: { released_pulse in
+///     // Handle anchor closing the stream
+///     await resource_service.release_resources()
+///   },
+///   handler: { pulse in
+///     // Process data flowing through the stream
+///     await resource_service.process(pulse.data)
+///   }
+/// )
+///
+/// // Send data through the stream
+/// let result = await resource_stream.send(data_pulse)
+///
+/// // Release the stream when no longer needed
+/// await resource_stream.release()
+/// ```
+final public actor Stream<Data: Pulsable>: Streaming {
+  /// Unique identifier for this stream
+  public let id: UUID = UUID()
+
+  // Primary data channel from source to sink
+  private var data_channel: Optional<Channel<Data>>
+
+  // Source closure notification channel
+  private var source_released_channel: Optional<Channel<StreamReleased>>
+
+  // Anchor closure notification channel
+  private var anchor_released_channel: Optional<Channel<StreamReleased>>
+
+  /// Creates a new stream with the specified handlers.
+  ///
+  /// This initializer establishes the three internal channels that form the stream's
+  /// communication infrastructure:
+  /// - A data channel for the primary message flow
+  /// - Optional notification channels for lifecycle events
+  ///
+  /// The notification channels are only created if handlers are provided, allowing
+  /// for efficient resource usage when full bidirectional awareness isn't needed.
+  /// Each notification channel is dedicated to a specific direction of release
+  /// notification, ensuring clear separation of concerns and predictable behavior.
+  ///
+  /// ```swift
+  /// // Create a stream with both lifecycle handlers
+  /// let full_stream = Stream(
+  ///   source_released: { released_pulse in
+  ///     handle_source_disconnect()
+  ///   },
+  ///   anchor_released: { released_pulse in
+  ///     handle_anchor_disconnect()
+  ///   },
+  ///   handler: message_processor.handle
+  /// )
+  ///
+  /// // Create a stream with only source release notification
+  /// let source_aware_stream = Stream(
+  ///   source_released: { released_pulse in handle_source_disconnect() },
+  ///   handler: message_processor.handle
+  /// )
+  ///
+  /// // Create a simple stream with no lifecycle awareness
+  /// let simple_stream = Stream(
+  ///   handler: message_processor.handle
+  /// )
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - source_released: Optional handler notified when source closes the stream
+  ///   - anchor_released: Optional handler notified when anchor closes the stream
+  ///   - handler: Handler that processes data flowing from source to anchor
+  public init(
+    source_released: Optional<ChannelHandler<StreamReleased>> = .none,
+    anchor_released: Optional<ChannelHandler<StreamReleased>> = .none,
+    handler: @escaping ChannelHandler<Data>
+  ) {
+    // Create the data channel
+    self.data_channel = Channel(handler: handler)
+
+    // Create the source closed notification channel only if a handler is provided
+    self.source_released_channel = source_released.transform { handler in
+      Channel(handler: handler)
+    }
+
+    // Create the anchor closed notification channel only if a handler is provided
+    self.anchor_released_channel = anchor_released.transform { handler in
+      Channel(handler: handler)
+    }
+  }
+
+  /// Sends data from the source to the sink.
+  ///
+  /// This method forwards the provided pulse to the stream's internal data channel
+  /// for processing by the registered data handler. It follows the fire-and-forget
+  /// pattern, but with additional checking for stream release status.
+  ///
+  /// If the stream has been released (data_channel is nil), the method immediately
+  /// returns a failure result without attempting to send the pulse. This behavior
+  /// ensures that attempts to use a released stream produce consistent, predictable
+  /// responses rather than unexpected errors.
+  ///
+  /// ```swift
+  /// // Send a data pulse through the stream
+  /// let result = await stream.send(data_pulse)
+  ///
+  /// // Check if the stream was available
+  /// if case .failure(.released) = result {
+  ///   // Handle the case where the stream was already released
+  ///   recreate_stream_connection()
+  /// }
+  /// ```
+  ///
+  /// - Parameter pulse: The typed pulse to send through this stream
+  /// - Returns: A result indicating success or a specific stream error
+  @discardableResult
+  public func send(_ pulse: Pulse<Data>) async -> StreamResult {
+    return data_channel.transform { channel in
+      channel.send(pulse)
+      return StreamResult.success
+    }.otherwise(StreamResult.failure(.released))
+  }
+
+  /// Releases the stream, preventing further pulse processing.
+  ///
+  /// This method performs a complete shutdown of the stream by:
+  /// 1. Checking if the stream is already released (data_channel is nil)
+  /// 2. Sending release notifications through both notification channels (if they exist)
+  ///    including the stream's unique ID both directly and via metadata
+  /// 3. Clearing all channel references to allow proper resource cleanup
+  ///
+  /// The release process follows a careful sequence to ensure that all notifications
+  /// are sent before the data channel is cleared, providing connected components
+  /// with an opportunity to react to the stream closure.
+  ///
+  /// ```swift
+  /// // Release a stream when it's no longer needed
+  /// let result = await stream.release()
+  ///
+  /// if case .success = result {
+  ///   // Stream was successfully released
+  ///   log_event("Stream shutdown completed")
+  /// } else {
+  ///   // Stream was already released
+  ///   log_warning("Attempted to release an already released stream")
+  /// }
+  /// ```
+  ///
+  /// - Returns: A result indicating success or a specific stream error
+  @discardableResult
+  public func release() async -> StreamResult {
+    guard let _ = data_channel else { return .failure(.released) }
+    let release_pulse = Pulse(StreamReleased(stream_id: id)).from(self)
+
+    source_released_channel = source_released_channel.transform { channel in
+      channel.send(release_pulse)
+      return .none
+    }
+
+    anchor_released_channel = anchor_released_channel.transform { channel in
+      channel.send(release_pulse)
+      return .none
+    }
+
+    data_channel = .none
+
+    return .success
+  }
+}

--- a/Sources/Flow/Stream/Types/ChannelError.swift
+++ b/Sources/Flow/Stream/Types/ChannelError.swift
@@ -1,0 +1,35 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Represents specific error conditions that can occur during stream operations.
+///
+/// `StreamError` encapsulates the primary failure mode for stream operations:
+/// attempting to interact with a stream that has been released.
+///
+/// This error is returned as part of a `StreamResult` rather than thrown,
+/// aligning with Obsidian's design principle of non-throwing code. This approach
+/// encourages explicit error handling and predictable control flow.
+///
+/// ```swift
+/// // Handle stream errors in a switch statement
+/// switch result {
+/// case .success:
+///   continue_processing()
+///
+/// case .failure(.released):
+///   reconnect_stream()
+/// }
+/// ```
+///
+/// The error case is designed to provide just enough context for proper error
+/// handling without exposing unnecessary implementation details.
+@frozen public enum StreamError: Error {
+  /// Indicates that the stream has been released and can no longer process pulses.
+  ///
+  /// This error occurs when attempting to send a pulse to a stream that has been
+  /// explicitly released, or when attempting to release a stream that has
+  /// already been released.
+  case released
+}

--- a/Sources/Flow/Stream/Types/ChannelResult.swift
+++ b/Sources/Flow/Stream/Types/ChannelResult.swift
@@ -1,0 +1,34 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+/// Type alias representing the result of a stream operation.
+///
+/// `StreamResult` provides a standardized way to handle the outcome of operations
+/// performed on a stream, such as sending a pulse or releasing a stream. The Result
+/// type encapsulates either success (Void) or failure with a specific StreamError.
+///
+/// Using Result instead of throwing functions aligns with Obsidian's design principle
+/// of non-throwing code, allowing for explicit error handling patterns that are both
+/// predictable and composable.
+///
+/// ```swift
+/// // Process a stream operation result
+/// let result = await stream.send(pulse)
+///
+/// switch result {
+/// case .success:
+///   // Operation succeeded
+///   break
+///
+/// case .failure(.released):
+///   // Stream was already released
+///   handle_released_stream()
+/// }
+/// ```
+///
+/// Stream operations that can fail return this result type, allowing callers
+/// to determine whether the operation completed successfully or encountered
+/// a specific error condition.
+public typealias StreamResult = Result<Void, StreamError>

--- a/Tests/Flow/ChannelTests/ChannelTests.swift
+++ b/Tests/Flow/ChannelTests/ChannelTests.swift
@@ -1,0 +1,163 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Channel/Core: Channel")
+struct ChannelTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulseData: Pulsable {
+    let message: String
+  }
+  
+  func create_test_pulse() -> Pulse<TestPulseData> {
+    return Pulse(TestPulseData(message: "Test Message"))
+  }
+  
+  // MARK: - Initialization Tests
+  
+  @Test("initializes with handler")
+  func initializes_with_handler() throws {
+    // Given
+    let handler: ChannelHandler<TestPulseData> = { _ in }
+    
+    // When
+    let _ = Channel(handler: handler)
+    
+    // Then
+    // If initialization failed, this would have thrown an error
+    // No assertion needed - the test passes if no error is thrown
+  }
+  
+  // MARK: - Send Tests
+  
+  @Test("send delivers pulse to handler")
+  func send_delivers_pulse_to_handler() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let expected_message = pulse.data.message
+    
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestPulseData> = { received_pulse in
+        #expect(received_pulse.data.message == expected_message)
+        confirm()
+      }
+      
+      let channel = Channel(handler: handler)
+      channel.send(pulse)
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("send processes multiple pulses")
+  func send_processes_multiple_pulses() async throws {
+    // Given
+    let pulse1 = Pulse(TestPulseData(message: "First"))
+    let pulse2 = Pulse(TestPulseData(message: "Second"))
+    let pulse3 = Pulse(TestPulseData(message: "Third"))
+    
+    // When/Then
+    try await confirmation(expectedCount: 3) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestPulseData> = { received_pulse in
+        // Verify we received one of the expected messages
+        let message = received_pulse.data.message
+        #expect(["First", "Second", "Third"].contains(message))
+        confirm()
+      }
+      
+      let channel = Channel(handler: handler)
+      
+      channel.send(pulse1)
+      channel.send(pulse2)
+      channel.send(pulse3)
+      
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("handler retains references as documented")
+  func handler_retains_references_as_documented() async throws {
+    // Given
+    weak var weak_service: TestService?
+    let pulse = create_test_pulse()
+    
+    // When
+    let channel = {
+      let service = TestService()
+      weak_service = service
+      
+      let handler: ChannelHandler<TestPulseData> = { _ in
+        // Reference the service to create a retention cycle
+        await service.process_message()
+      }
+      
+      return Channel(handler: handler)
+    }()
+    
+    // Then - service should still be alive because channel retains the handler
+    #expect(weak_service != nil, "Service should be retained by channel's handler")
+    
+    // Clean up
+    channel.send(pulse)
+    try await Task.sleep(for: .milliseconds(100))
+  }
+
+  // MARK: - Task Priority Tests
+  
+  @Test("send creates task with pulse priority")
+  func send_creates_task_with_pulse_priority() async throws {
+    // Given
+    let pulse = create_test_pulse().priority(.high)
+    
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestPulseData> = { _ in
+        let current_priority = Task.currentPriority
+        #expect(current_priority == .high)
+        confirm()
+      }
+      
+      let channel = Channel(handler: handler)
+      channel.send(pulse)
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("send preserves different priority levels")
+  func send_preserves_different_priority_levels() async throws {
+    // Given
+    let low_pulse = create_test_pulse().priority(.low)
+    let high_pulse = create_test_pulse().priority(.high)
+    
+    // When/Then
+    try await confirmation(expectedCount: 2) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestPulseData> = { received_pulse in
+        let current_priority = Task.currentPriority
+        let expected_priority = received_pulse.priority
+        #expect(current_priority == expected_priority)
+        confirm()
+      }
+      
+      let channel = Channel(handler: handler)
+      channel.send(low_pulse)
+      channel.send(high_pulse)
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  // MARK: - Helper Types
+  
+  actor TestService {
+    func process_message() async {
+      // Simulate some work
+      try? await Task.sleep(for: .milliseconds(10))
+    }
+  }
+}

--- a/Tests/Flow/PulseTests/Extensions/Pulse/FluentBuilderTests.swift
+++ b/Tests/Flow/PulseTests/Extensions/Pulse/FluentBuilderTests.swift
@@ -1,0 +1,412 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Extensions: Pulse/FluentBuilder")
+struct PulseFluentBuilderTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulseData: Pulsable {
+    let value: String
+  }
+  
+  func create_test_data(value: String = "Test Value") -> TestPulseData {
+    return TestPulseData(value: value)
+  }
+  
+  func create_test_pulse(debug: Bool = false, tags: Set<String> = []) -> Pulse<TestPulseData> {
+    let data = create_test_data()
+    let meta = PulseMeta(debug: debug, tags: tags)
+    return Pulse(id: UUID(), timestamp: Date(), data: data, meta: meta)
+  }
+  
+  // MARK: - Debug Tests
+  
+  @Test("debug defaults to enabled")
+  func debug_defaults_to_enabled() throws {
+    // Given
+    let pulse = create_test_pulse()
+    
+    // When
+    let result = pulse.debug()
+    
+    // Then
+    #expect(result.meta.debug == true)
+  }
+  
+  @Test("debug accepts explicit values")
+  func debug_accepts_explicit_values() throws {
+    // Given
+    let pulse = create_test_pulse()
+    
+    // When
+    let enabled = pulse.debug(true)
+    let disabled = pulse.debug(false)
+    
+    // Then
+    #expect(enabled.meta.debug == true)
+    #expect(disabled.meta.debug == false)
+  }
+  
+  @Test("debug returns new pulse")
+  func debug_returns_new_pulse() throws {
+    // Given
+    let original = create_test_pulse()
+    
+    // When
+    let result = original.debug()
+    
+    // Then
+    #expect(result != original) // Reference check not applicable to structs
+    #expect(original.meta.debug == false) // Original unchanged
+  }
+  
+  @Test("debug preserves other metadata")
+  func debug_preserves_other_metadata() throws {
+    // Given
+    let custom_tags: Set<String> = ["test", "important"]
+    let pulse = create_test_pulse(tags: custom_tags)
+    
+    // When
+    let result = pulse.debug()
+    
+    // Then
+    #expect(result.meta.tags == custom_tags)
+  }
+  
+  // MARK: - Echoes Tests
+  
+  @Test("echoes sets echoes reference correctly")
+  func echoes_sets_echoes_reference_correctly() throws {
+    // Given
+    let original = create_test_pulse()
+    let pulse = create_test_pulse()
+    
+    // When
+    let result = pulse.echoes(original)
+    
+    // Then
+    #expect(result.meta.echoes != nil)
+    #expect(result.meta.echoes?.id == original.id)
+  }
+  
+  @Test("echoes copies trace id")
+  func echoes_copies_trace_id() throws {
+    // Given
+    let original = create_test_pulse()
+    let pulse = create_test_pulse()
+    
+    // When
+    let result = pulse.echoes(original)
+    
+    // Then
+    #expect(result.meta.trace == original.meta.trace)
+  }
+  
+  @Test("echoes preserves other metadata")
+  func echoes_preserves_other_metadata() throws {
+    // Given
+    let original = create_test_pulse()
+    let pulse = create_test_pulse(debug: true, tags: ["test"])
+    
+    // When
+    let result = pulse.echoes(original)
+    
+    // Then
+    #expect(result.meta.debug == true)
+    #expect(result.meta.tags.contains("test"))
+  }
+  
+  @Test("echoes works with different data types")
+  func echoes_works_with_different_data_types() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let original = Pulse(OtherPulseData(id: 42))
+    let pulse = create_test_pulse()
+    
+    // When
+    let result = pulse.echoes(original)
+    
+    // Then
+    #expect(result.meta.echoes != nil)
+    #expect(result.meta.echoes?.id == original.id)
+  }
+  
+  // MARK: - Source Tests
+  
+  @Test("from sets source correctly")
+  func from_sets_source_correctly() throws {
+    // Given
+    struct TestSource: Representable {
+      let id = UUID()
+      let name = "Test Source"
+    }
+    
+    let source = TestSource()
+    let pulse = create_test_pulse()
+    
+    // When
+    let result = pulse.from(source)
+    
+    // Then
+    #expect(result.meta.source != nil)
+    #expect(result.meta.source?.id == source.id)
+    #expect(result.meta.source?.name == source.name)
+  }
+  
+  @Test("from preserves other metadata")
+  func from_preserves_other_metadata() throws {
+    // Given
+    struct TestSource: Representable {
+      let id = UUID()
+      let name = "Test Source"
+    }
+    
+    let source = TestSource()
+    let pulse = create_test_pulse(debug: true, tags: ["test"])
+    
+    // When
+    let result = pulse.from(source)
+    
+    // Then
+    #expect(result.meta.debug == true)
+    #expect(result.meta.tags.contains("test"))
+  }
+  
+  // MARK: - Priority Tests
+  
+  @Test("priority sets priority correctly")
+  func priority_sets_priority_correctly() throws {
+    // Given
+    let pulse = create_test_pulse()
+    
+    // When
+    let high_priority = pulse.priority(.high)
+    let low_priority = pulse.priority(.low)
+    
+    // Then
+    #expect(high_priority.priority == .high)
+    #expect(low_priority.priority == .low)
+  }
+  
+  @Test("priority preserves other metadata")
+  func priority_preserves_other_metadata() throws {
+    // Given
+    let pulse = create_test_pulse(debug: true, tags: ["test"])
+    
+    // When
+    let result = pulse.priority(.high)
+    
+    // Then
+    #expect(result.meta.debug == true)
+    #expect(result.meta.tags.contains("test"))
+  }
+  
+  // MARK: - Tags Tests
+  
+  @Test("tagged adds tags by default")
+  func tagged_adds_tags_by_default() throws {
+    // Given
+    let original_tags: Set<String> = ["original"]
+    let pulse = create_test_pulse(tags: original_tags)
+    
+    // When
+    let result = pulse.tagged("new", "extra")
+    
+    // Then
+    #expect(result.meta.tags.contains("original"))
+    #expect(result.meta.tags.contains("new"))
+    #expect(result.meta.tags.contains("extra"))
+    #expect(result.meta.tags.count == 3)
+  }
+  
+  @Test("tagged with reset replaces existing tags")
+  func tagged_with_reset_replaces_existing_tags() throws {
+    // Given
+    let original_tags: Set<String> = ["original", "test"]
+    let pulse = create_test_pulse(tags: original_tags)
+    
+    // When
+    let result = pulse.tagged("new", "extra", reset: true)
+    
+    // Then
+    #expect(!result.meta.tags.contains("original"))
+    #expect(!result.meta.tags.contains("test"))
+    #expect(result.meta.tags.contains("new"))
+    #expect(result.meta.tags.contains("extra"))
+    #expect(result.meta.tags.count == 2)
+  }
+  
+  @Test("tagged with empty params preserves tags")
+  func tagged_with_empty_params_preserves_tags() throws {
+    // Given
+    let original_tags: Set<String> = ["original", "test"]
+    let pulse = create_test_pulse(tags: original_tags)
+    
+    // When
+    let result = pulse.tagged()
+    
+    // Then
+    #expect(result.meta.tags == original_tags)
+  }
+  
+  @Test("tagged with empty params and reset clears tags")
+  func tagged_with_empty_params_and_reset_clears_tags() throws {
+    // Given
+    let original_tags: Set<String> = ["original", "test"]
+    let pulse = create_test_pulse(tags: original_tags)
+    
+    // When
+    let result = pulse.tagged(reset: true)
+    
+    // Then
+    #expect(result.meta.tags.isEmpty)
+  }
+  
+  // MARK: - Like Tests
+  
+  @Test("like copies all metadata from source pulse")
+  func like_copies_all_metadata_from_source_pulse() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let source_meta = PulseMeta(
+      debug: true,
+      trace: UUID(),
+      priority: .high,
+      tags: ["template", "reference"]
+    )
+    let source = Pulse(id: UUID(), timestamp: Date(), data: OtherPulseData(id: 42), meta: source_meta)
+    let target = create_test_pulse()
+    
+    // When
+    let result = target.like(source)
+    
+    // Then
+    #expect(result.meta.debug == source.meta.debug)
+    #expect(result.meta.trace == source.meta.trace)
+    #expect(result.meta.priority == source.meta.priority)
+    #expect(result.meta.tags == source.meta.tags)
+  }
+  
+  @Test("like preserves original pulse data")
+  func like_preserves_original_pulse_data() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let source = Pulse(OtherPulseData(id: 42))
+    let target = Pulse(create_test_data(value: "Original Data"))
+    
+    // When
+    let result = target.like(source)
+    
+    // Then
+    #expect(result.data.value == "Original Data")
+  }
+  
+  @Test("like preserves original pulse identity")
+  func like_preserves_original_pulse_identity() throws {
+    // Given
+    struct OtherPulseData: Pulsable {
+      let id: Int
+    }
+    
+    let source = Pulse(OtherPulseData(id: 42))
+    let target = create_test_pulse()
+    
+    // When
+    let result = target.like(source)
+    
+    // Then
+    #expect(result.id == target.id)
+    #expect(result.timestamp == target.timestamp)
+  }
+  
+  // MARK: - Chaining Tests
+  
+  @Test("chaining multiple methods works correctly")
+  func chaining_multiple_methods_works_correctly() throws {
+    // Given
+    struct TestSource: Representable {
+      let id = UUID()
+      let name = "Test Source"
+    }
+    
+    let source = TestSource()
+    let pulse = create_test_pulse()
+    
+    // When
+    let result = pulse
+      .debug()
+      .priority(.high)
+      .tagged("important", "critical")
+      .from(source)
+    
+    // Then
+    #expect(result.meta.debug == true)
+    #expect(result.priority == .high)
+    #expect(result.meta.tags.contains("important"))
+    #expect(result.meta.tags.contains("critical"))
+    #expect(result.meta.source?.id == source.id)
+  }
+  
+  @Test("chaining order determines final state")
+  func chaining_order_determines_final_state() throws {
+    // Given
+    let pulse = create_test_pulse()
+    
+    // When - debug(true) followed by debug(false)
+    let result1 = pulse.debug(true).debug(false)
+    
+    // When - debug(false) followed by debug(true)
+    let result2 = pulse.debug(false).debug(true)
+    
+    // Then
+    #expect(result1.meta.debug == false)
+    #expect(result2.meta.debug == true)
+  }
+  
+  // MARK: - Immutability Tests
+  
+  @Test("original pulse remains unchanged after operations")
+  func original_pulse_remains_unchanged_after_operations() throws {
+    // Given
+    let original_tags: Set<String> = ["original"]
+    let pulse = create_test_pulse(tags: original_tags)
+    
+    // When - perform all operations
+    let _ = pulse.debug()
+    let _ = pulse.priority(.high)
+    let _ = pulse.tagged("new")
+    
+    struct TestSource: Representable {
+      let id = UUID()
+      let name = "Test Source"
+    }
+    let _ = pulse.from(TestSource())
+    
+    let echo_source = create_test_pulse()
+    let _ = pulse.echoes(echo_source)
+    
+    // Then - original should be unchanged
+    #expect(pulse.meta.debug == false)
+    #expect(pulse.priority == .medium) // Default value
+    #expect(pulse.meta.tags == original_tags)
+    #expect(pulse.meta.source == nil)
+    #expect(pulse.meta.echoes == nil)
+  }
+}

--- a/Tests/Flow/PulseTests/Extensions/Pulse/PulseFluentlyTests.swift
+++ b/Tests/Flow/PulseTests/Extensions/Pulse/PulseFluentlyTests.swift
@@ -1,0 +1,235 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Extensions: Pulse/PulseFluently")
+struct PulseFluencyTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulseData: Pulsable {
+    let value: String
+  }
+  
+  func create_test_data(value: String = "Original Data") -> TestPulseData {
+    return TestPulseData(value: value)
+  }
+  
+  // MARK: - Static Fluently Tests
+  
+  @Test("static Fluently preserves pulse id")
+  func static_fluently_preserves_pulse_id() throws {
+    let original = Pulse(create_test_data())
+    let updated = Pulse.Fluently(original)
+    
+    #expect(updated.id == original.id)
+  }
+  
+  @Test("static Fluently preserves pulse timestamp")
+  func static_fluently_preserves_pulse_timestamp() throws {
+    let original = Pulse(create_test_data())
+    let updated = Pulse.Fluently(original)
+    
+    #expect(updated.timestamp == original.timestamp)
+  }
+  
+  @Test("static Fluently preserves data when not specified")
+  func static_fluently_preserves_data_when_not_specified() throws {
+    let original_data = create_test_data()
+    let original = Pulse(original_data)
+    
+    let updated = Pulse.Fluently(original)
+    
+    #expect(updated.data.value == original_data.value)
+  }
+  
+  @Test("static Fluently preserves metadata when not specified")
+  func static_fluently_preserves_metadata_when_not_specified() throws {
+    let original = Pulse(create_test_data())
+    
+    let updated = Pulse.Fluently(original)
+    
+    #expect(updated.meta.debug == original.meta.debug)
+    #expect(updated.meta.trace == original.meta.trace)
+    #expect(updated.meta.priority == original.meta.priority)
+    #expect(updated.meta.tags == original.meta.tags)
+  }
+  
+  @Test("static Fluently updates data when specified")
+  func static_fluently_updates_data_when_specified() throws {
+    let original_data = create_test_data(value: "Original Data")
+    let new_data = create_test_data(value: "New Data")
+    let original = Pulse(original_data)
+    
+    let updated = Pulse.Fluently(original, data: new_data)
+    
+    #expect(updated.data.value == "New Data")
+  }
+  
+  @Test("static Fluently updates metadata when specified")
+  func static_fluently_updates_metadata_when_specified() throws {
+    let original = Pulse(create_test_data())
+    let new_meta = PulseMeta(debug: true, priority: .high, tags: ["test"])
+    
+    let updated = Pulse.Fluently(original, meta: new_meta)
+    
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+    #expect(updated.meta.tags.contains("test"))
+  }
+  
+  @Test("static Fluently updates both data and metadata when specified")
+  func static_fluently_updates_both_when_specified() throws {
+    let original_data = create_test_data(value: "Original Data")
+    let new_data = create_test_data(value: "New Data")
+    let original = Pulse(original_data)
+    let new_meta = PulseMeta(debug: true, priority: .high)
+    
+    let updated = Pulse.Fluently(original, data: new_data, meta: new_meta)
+    
+    #expect(updated.data.value == "New Data")
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+  }
+  
+  // MARK: - Instance Fluently Tests
+  
+  @Test("instance fluently preserves pulse id")
+  func instance_fluently_preserves_pulse_id() throws {
+    let original = Pulse(create_test_data())
+    let updated = original.fluently()
+    
+    #expect(updated.id == original.id)
+  }
+  
+  @Test("instance fluently preserves pulse timestamp")
+  func instance_fluently_preserves_pulse_timestamp() throws {
+    let original = Pulse(create_test_data())
+    let updated = original.fluently()
+    
+    #expect(updated.timestamp == original.timestamp)
+  }
+  
+  @Test("instance fluently preserves data when not specified")
+  func instance_fluently_preserves_data_when_not_specified() throws {
+    let original_data = create_test_data()
+    let original = Pulse(original_data)
+    
+    let updated = original.fluently()
+    
+    #expect(updated.data.value == original_data.value)
+  }
+  
+  @Test("instance fluently preserves metadata when not specified")
+  func instance_fluently_preserves_metadata_when_not_specified() throws {
+    let original = Pulse(create_test_data())
+    
+    let updated = original.fluently()
+    
+    #expect(updated.meta.debug == original.meta.debug)
+    #expect(updated.meta.trace == original.meta.trace)
+    #expect(updated.meta.priority == original.meta.priority)
+    #expect(updated.meta.tags == original.meta.tags)
+  }
+  
+  @Test("instance fluently updates data when specified")
+  func instance_fluently_updates_data_when_specified() throws {
+    let original_data = create_test_data(value: "Original Data")
+    let new_data = create_test_data(value: "New Data")
+    let original = Pulse(original_data)
+    
+    let updated = original.fluently(data: new_data)
+    
+    #expect(updated.data.value == "New Data")
+  }
+  
+  @Test("instance fluently updates metadata when specified")
+  func instance_fluently_updates_metadata_when_specified() throws {
+    let original = Pulse(create_test_data())
+    let new_meta = PulseMeta(debug: true, priority: .high, tags: ["test"])
+    
+    let updated = original.fluently(meta: new_meta)
+    
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+    #expect(updated.meta.tags.contains("test"))
+  }
+  
+  @Test("instance fluently updates both data and metadata when specified")
+  func instance_fluently_updates_both_when_specified() throws {
+    let original_data = create_test_data(value: "Original Data")
+    let new_data = create_test_data(value: "New Data")
+    let original = Pulse(original_data)
+    let new_meta = PulseMeta(debug: true, priority: .high)
+    
+    let updated = original.fluently(data: new_data, meta: new_meta)
+    
+    #expect(updated.data.value == "New Data")
+    #expect(updated.meta.debug == true)
+    #expect(updated.meta.priority == TaskPriority.high.rawValue)
+  }
+  
+  // MARK: - Instance vs Static Tests
+  
+  @Test("instance fluently forwards to static Fluently")
+  func instance_fluently_forwards_to_static_fluently() throws {
+    let original = Pulse(create_test_data())
+    let new_data = create_test_data(value: "New Data")
+    let new_meta = PulseMeta(debug: true)
+    
+    let static_result = Pulse.Fluently(original, data: new_data, meta: new_meta)
+    let instance_result = original.fluently(data: new_data, meta: new_meta)
+    
+    #expect(instance_result.id == static_result.id)
+    #expect(instance_result.timestamp == static_result.timestamp)
+    #expect(instance_result.data.value == static_result.data.value)
+    #expect(instance_result.meta.debug == static_result.meta.debug)
+  }
+  
+  // MARK: - Immutability Tests
+  
+  @Test("fluently maintains immutability of original pulse")
+  func fluently_maintains_immutability_of_original_pulse() throws {
+    let original_data = create_test_data(value: "Original Data")
+    let original = Pulse(original_data)
+    
+    let _ = original.fluently(
+      data: create_test_data(value: "New Data"),
+      meta: PulseMeta(debug: true)
+    )
+    
+    #expect(original.data.value == "Original Data")
+    #expect(!original.meta.debug)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("fluently with no changes creates equal pulse")
+  func fluently_with_no_changes_creates_equal_pulse() throws {
+    let original = Pulse(create_test_data())
+    let updated = original.fluently()
+    
+    #expect(updated == original)
+  }
+  
+  @Test("fluently with data change creates non-equal pulse")
+  func fluently_with_data_change_creates_non_equal_pulse() throws {
+    let original = Pulse(create_test_data(value: "Original"))
+    let updated = original.fluently(data: create_test_data(value: "Modified"))
+    
+    #expect(updated != original)
+  }
+  
+  @Test("fluently with metadata change creates non-equal pulse")
+  func fluently_with_metadata_change_creates_non_equal_pulse() throws {
+    let original = Pulse(create_test_data())
+    let updated = original.fluently(meta: PulseMeta(debug: true))
+    
+    #expect(updated != original)
+  }
+}

--- a/Tests/Flow/PulseTests/Extensions/Pulse/RespondTests.swift
+++ b/Tests/Flow/PulseTests/Extensions/Pulse/RespondTests.swift
@@ -1,0 +1,223 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Extensions: Pulse/Respond")
+struct PulseRespondTests {
+  
+  // MARK: - Test Data
+  
+  struct OriginalPulseData: Pulsable {
+    let message: String
+  }
+  
+  struct ResponsePulseData: Pulsable {
+    let success: Bool
+    let details: String
+  }
+  
+  struct TestSource: Representable {
+    let id = UUID()
+    let name = "Test Response Source"
+  }
+  
+  func create_original_pulse() -> Pulse<OriginalPulseData> {
+    return Pulse(OriginalPulseData(message: "Test Message"))
+  }
+  
+  func create_response_data() -> ResponsePulseData {
+    return ResponsePulseData(success: true, details: "Successfully processed")
+  }
+  
+  // MARK: - Basic Functionality Tests
+  
+  @Test("creates a new pulse with the provided data")
+  func creates_new_pulse_with_provided_data() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.data.success == true)
+    #expect(response.data.details == "Successfully processed")
+  }
+  
+  @Test("assigns a new UUID to the response pulse")
+  func assigns_new_uuid_to_response_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.id != original.id)
+  }
+  
+  @Test("sets a new timestamp on the response pulse")
+  func sets_new_timestamp_on_response_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let before = Date()
+    let response = Pulse.Respond(to: original, with: response_data)
+    let after = Date()
+    
+    // Then
+    #expect(response.timestamp != original.timestamp)
+    #expect(response.timestamp >= before)
+    #expect(response.timestamp <= after)
+  }
+  
+  // MARK: - Metadata Tests
+  
+  @Test("copies trace ID from original pulse")
+  func copies_trace_id_from_original_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.meta.trace == original.meta.trace)
+  }
+  
+  @Test("sets echoes reference to the original pulse")
+  func sets_echoes_reference_to_original_pulse() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.meta.echoes != nil)
+    #expect(response.meta.echoes?.id == original.id)
+    #expect(response.meta.echoes?.name == original.name)
+  }
+  
+  @Test("does not set source when none is provided")
+  func does_not_set_source_when_none_provided() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(response.meta.source == nil)
+  }
+  
+  @Test("sets source when one is provided")
+  func sets_source_when_one_provided() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    let source = TestSource()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data, from: source)
+    
+    // Then
+    #expect(response.meta.source != nil)
+    #expect(response.meta.source?.id == source.id)
+    #expect(response.meta.source?.name == source.name)
+  }
+  
+  // MARK: - Cross-Type Tests
+  
+  @Test("works with different data types")
+  func works_with_different_data_types() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    #expect(type(of: original.data) == OriginalPulseData.self)
+    #expect(type(of: response.data) == ResponsePulseData.self)
+  }
+  
+  // MARK: - Complex Scenarios
+  
+  @Test("preserves original pulse debug flag")
+  func preserves_original_pulse_debug_flag() throws {
+    // Given
+    let original = create_original_pulse().debug(true)
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    // Debug flag should NOT be preserved - only trace and echoes are copied
+    #expect(response.meta.debug == false)
+  }
+  
+  @Test("preserves original pulse priority")
+  func preserves_original_pulse_priority() throws {
+    // Given
+    let original = create_original_pulse().priority(.high)
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    // Priority should NOT be preserved - only trace and echoes are copied
+    #expect(response.priority == .medium) // Default value
+  }
+  
+  @Test("preserves original pulse tags")
+  func preserves_original_pulse_tags() throws {
+    // Given
+    let original = create_original_pulse().tagged("important", "test")
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+    
+    // Then
+    // Tags should NOT be preserved - only trace and echoes are copied
+    #expect(response.meta.tags.isEmpty)
+  }
+  
+  @Test("can be combined with other fluent methods")
+  func can_be_combined_with_other_fluent_methods() throws {
+    // Given
+    let original = create_original_pulse()
+    let response_data = create_response_data()
+    
+    // When
+    let response = Pulse.Respond(to: original, with: response_data)
+      .debug(true)
+      .priority(.high)
+      .tagged("response", "processed")
+    
+    // Then
+    #expect(response.meta.debug == true)
+    #expect(response.priority == .high)
+    #expect(response.meta.tags.contains("response"))
+    #expect(response.meta.tags.contains("processed"))
+    #expect(response.meta.trace == original.meta.trace)
+    #expect(response.meta.echoes?.id == original.id)
+  }
+}

--- a/Tests/Flow/PulseTests/Extensions/PulseMeta/MetaFluentlyTests.swift
+++ b/Tests/Flow/PulseTests/Extensions/PulseMeta/MetaFluentlyTests.swift
@@ -1,0 +1,220 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Extensions: PulseMeta/MetaFluently")
+struct PulseMetaFluentlyTests {
+  
+  // MARK: - Test Data
+  
+  struct TestRepresentable: Representable {
+    let id = UUID()
+    let name = "Test Source"
+  }
+  
+  // MARK: - Static Fluently Method Tests
+  
+  @Test("Fluently preserves trace when not specified")
+  func fluently_preserves_trace_when_not_specified() throws {
+    let original = PulseMeta()
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    #expect(updated.trace == original.trace)
+  }
+  
+  @Test("Fluently preserves source when not specified")
+  func fluently_preserves_source_when_not_specified() throws {
+    let original = PulseMeta()
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    #expect(updated.source == original.source)
+  }
+  
+  @Test("Fluently preserves echoes when not specified")
+  func fluently_preserves_echoes_when_not_specified() throws {
+    let original = PulseMeta()
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    #expect(updated.echoes == original.echoes)
+  }
+  
+  @Test("Fluently preserves priority when not specified")
+  func fluently_preserves_priority_when_not_specified() throws {
+    let original = PulseMeta()
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    #expect(updated.priority == original.priority)
+  }
+  
+  @Test("Fluently preserves tags when not specified")
+  func fluently_preserves_tags_when_not_specified() throws {
+    let original = PulseMeta()
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    #expect(updated.tags == original.tags)
+  }
+  
+  @Test("Fluently updates debug flag")
+  func fluently_updates_debug_flag() throws {
+    let original = PulseMeta(debug: false)
+    let updated = PulseMeta.Fluently(original, debug: true)
+    
+    #expect(original.debug == false)
+    #expect(updated.debug == true)
+  }
+  
+  @Test("Fluently updates trace")
+  func fluently_updates_trace() throws {
+    let original = PulseMeta()
+    let new_trace = UUID()
+    
+    let updated = PulseMeta.Fluently(original, trace: new_trace)
+    
+    #expect(updated.trace == new_trace)
+    #expect(updated.trace != original.trace)
+  }
+  
+  @Test("Fluently updates source")
+  func fluently_updates_source() throws {
+    let original = PulseMeta()
+    let source = PulseSource.From(source: TestRepresentable())
+    
+    let updated = PulseMeta.Fluently(original, source: source)
+    
+    #expect(updated.source?.id == source.id)
+    #expect(updated.source?.name == source.name)
+  }
+  
+  @Test("Fluently updates echoes")
+  func fluently_updates_echoes() throws {
+    let original = PulseMeta()
+    let echo = PulseSource.From(source: TestRepresentable())
+    
+    let updated = PulseMeta.Fluently(original, echoes: echo)
+    
+    #expect(updated.echoes?.id == echo.id)
+    #expect(updated.echoes?.name == echo.name)
+  }
+  
+  @Test("Fluently updates priority")
+  func fluently_updates_priority() throws {
+    let original = PulseMeta(priority: .low)
+    let updated = PulseMeta.Fluently(original, priority: .high)
+    
+    #expect(updated.priority == TaskPriority.high.rawValue)
+    #expect(updated.priority != original.priority)
+  }
+  
+  @Test("Fluently updates tags")
+  func fluently_updates_tags() throws {
+    let original = PulseMeta()
+    let new_tags: Set<String> = ["test", "fluent"]
+    
+    let updated = PulseMeta.Fluently(original, tags: new_tags)
+    
+    #expect(updated.tags == new_tags)
+    #expect(updated.tags != original.tags)
+  }
+  
+  @Test("Fluently replaces tags with empty set when specified")
+  func fluently_replaces_tags_with_empty_set_when_specified() throws {
+    let original = PulseMeta(tags: ["original"])
+    let empty_tags: Set<String> = []
+    
+    let updated = PulseMeta.Fluently(original, tags: empty_tags)
+    
+    #expect(updated.tags.isEmpty)
+    #expect(updated.tags != original.tags)
+  }
+  
+  // MARK: - Instance Fluently Method Tests
+  
+  @Test("instance fluently forwards to static Fluently")
+  func instance_fluently_forwards_to_static_fluently() throws {
+    let original = PulseMeta()
+    let debug = true
+    
+    let static_result = PulseMeta.Fluently(original, debug: debug)
+    let instance_result = original.fluently(debug: debug)
+    
+    #expect(static_result.debug == instance_result.debug)
+    #expect(static_result.trace == instance_result.trace)
+    #expect(static_result.source == instance_result.source)
+    #expect(static_result.echoes == instance_result.echoes)
+    #expect(static_result.priority == instance_result.priority)
+    #expect(static_result.tags == instance_result.tags)
+  }
+  
+  @Test("instance fluently can update debug flag")
+  func instance_fluently_can_update_debug_flag() throws {
+    let original = PulseMeta(debug: false)
+    let result = original.fluently(debug: true)
+    
+    #expect(result.debug == true)
+    #expect(original.debug == false)
+  }
+  
+  @Test("instance fluently can update trace")
+  func instance_fluently_can_update_trace() throws {
+    let original = PulseMeta()
+    let new_trace = UUID()
+    
+    let result = original.fluently(trace: new_trace)
+    
+    #expect(result.trace == new_trace)
+    #expect(result.trace != original.trace)
+  }
+  
+  @Test("instance fluently can update priority")
+  func instance_fluently_can_update_priority() throws {
+    let original = PulseMeta(priority: .low)
+    let result = original.fluently(priority: .high)
+    
+    #expect(result.priority == TaskPriority.high.rawValue)
+    #expect(result.priority != original.priority)
+  }
+  
+  @Test("instance fluently enables method chaining")
+  func instance_fluently_enables_method_chaining() throws {
+    let original = PulseMeta()
+    
+    let result = original
+      .fluently(debug: true)
+      .fluently(priority: .high)
+    
+    #expect(result.debug == true)
+    #expect(result.priority == TaskPriority.high.rawValue)
+  }
+  
+  @Test("instance fluently maintains immutability")
+  func instance_fluently_maintains_immutability() throws {
+    let original = PulseMeta(debug: false, priority: .low)
+    
+    let _ = original.fluently(debug: true, priority: .high)
+    
+    #expect(original.debug == false)
+    #expect(original.priority == TaskPriority.low.rawValue)
+  }
+  
+  @Test("instance fluently updates multiple properties in one call")
+  func instance_fluently_updates_multiple_properties() throws {
+    let original = PulseMeta()
+    let new_trace = UUID()
+    
+    let updated = original.fluently(
+      debug: true,
+      trace: new_trace,
+      priority: .high
+    )
+    
+    #expect(updated.debug == true)
+    #expect(updated.trace == new_trace)
+    #expect(updated.priority == TaskPriority.high.rawValue)
+  }
+}

--- a/Tests/Flow/PulseTests/Metadata/PulseMetaTests.swift
+++ b/Tests/Flow/PulseTests/Metadata/PulseMetaTests.swift
@@ -1,0 +1,263 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Metadata: PulseMeta")
+struct PulseMetaTests {
+  
+  // MARK: - Test Data
+  
+  struct TestRepresentable: Representable {
+    let id = UUID()
+    let name = "Test Source"
+  }
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Pulsable")
+  func conforms_to_pulsable() throws {
+    let is_pulsable = (PulseMeta.self as Any) is any Pulsable.Type
+    #expect(is_pulsable)
+  }
+  
+  // MARK: - Default Value Tests
+  
+  @Test("debug defaults to false")
+  func debug_defaults_to_false() throws {
+    let meta = PulseMeta()
+    #expect(!meta.debug)
+  }
+  
+  @Test("source defaults to nil")
+  func source_defaults_to_nil() throws {
+    let meta = PulseMeta()
+    #expect(meta.source == nil)
+  }
+  
+  @Test("echoes defaults to nil")
+  func echoes_defaults_to_nil() throws {
+    let meta = PulseMeta()
+    #expect(meta.echoes == nil)
+  }
+  
+  @Test("priority defaults to medium")
+  func priority_defaults_to_medium() throws {
+    let meta = PulseMeta()
+    #expect(meta.priority == TaskPriority.medium.rawValue)
+  }
+  
+  @Test("tags defaults to empty set")
+  func tags_defaults_to_empty_set() throws {
+    let meta = PulseMeta()
+    #expect(meta.tags.isEmpty)
+  }
+  
+  // MARK: - Custom Value Tests
+  
+  @Test("initializes with custom debug value")
+  func initializes_with_custom_debug_value() throws {
+    let meta = PulseMeta(debug: true)
+    #expect(meta.debug)
+  }
+  
+  @Test("initializes with custom trace value")
+  func initializes_with_custom_trace_value() throws {
+    let custom_trace = UUID()
+    let meta = PulseMeta(trace: custom_trace)
+    #expect(meta.trace == custom_trace)
+  }
+  
+  @Test("initializes with custom source value")
+  func initializes_with_custom_source_value() throws {
+    let source_representable = TestRepresentable()
+    let source = PulseSource.From(source: source_representable)
+    
+    let meta = PulseMeta(source: source)
+    
+    #expect(meta.source != nil)
+    #expect(meta.source?.id == source.id)
+    #expect(meta.source?.name == source.name)
+  }
+  
+  @Test("initializes with custom echoes value")
+  func initializes_with_custom_echoes_value() throws {
+    let echo_representable = TestRepresentable()
+    let echo = PulseSource.From(source: echo_representable)
+    
+    let meta = PulseMeta(echoes: echo)
+    
+    #expect(meta.echoes != nil)
+    #expect(meta.echoes?.id == echo.id)
+    #expect(meta.echoes?.name == echo.name)
+  }
+  
+  @Test("initializes with custom priority value")
+  func initializes_with_custom_priority_value() throws {
+    let meta = PulseMeta(priority: .high)
+    #expect(meta.priority == TaskPriority.high.rawValue)
+  }
+  
+  @Test("initializes with custom tags value")
+  func initializes_with_custom_tags_value() throws {
+    let custom_tags: Set<String> = ["feature_flag", "beta", "testing"]
+    
+    let meta = PulseMeta(tags: custom_tags)
+    
+    #expect(meta.tags == custom_tags)
+    #expect(meta.tags.count == 3)
+  }
+  
+  // MARK: - Serialization Tests
+  
+  @Test("can be encoded to JSON")
+  func can_be_encoded_to_json() throws {
+    let meta = PulseMeta(
+      debug: true,
+      trace: UUID(),
+      priority: .high,
+      tags: ["test", "serialization"]
+    )
+    
+    let encoder = JSONEncoder()
+    
+    // Should not throw
+    let _ = try encoder.encode(meta)
+  }
+  
+  @Test("can be decoded from JSON")
+  func can_be_decoded_from_json() throws {
+    let original = PulseMeta(
+      debug: true,
+      trace: UUID(),
+      priority: .high,
+      tags: ["test", "serialization"]
+    )
+    
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(PulseMeta.self, from: data)
+    
+    #expect(decoded.debug == original.debug)
+    #expect(decoded.trace == original.trace)
+    #expect(decoded.priority == original.priority)
+    #expect(decoded.tags == original.tags)
+  }
+  
+  @Test("preserves source when serialized")
+  func preserves_source_when_serialized() throws {
+    let source = PulseSource.From(source: TestRepresentable())
+    let original = PulseMeta(source: source)
+    
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(PulseMeta.self, from: data)
+    
+    #expect(decoded.source?.id == original.source?.id)
+    #expect(decoded.source?.name == original.source?.name)
+  }
+  
+  @Test("preserves echoes when serialized")
+  func preserves_echoes_when_serialized() throws {
+    let echo = PulseSource.From(source: TestRepresentable())
+    let original = PulseMeta(echoes: echo)
+    
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(PulseMeta.self, from: data)
+    
+    #expect(decoded.echoes?.id == original.echoes?.id)
+    #expect(decoded.echoes?.name == original.echoes?.name)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("instances with same properties are equal")
+  func instances_with_same_properties_are_equal() throws {
+    let trace_id = UUID()
+    let tags: Set<String> = ["tag1", "tag2"]
+    
+    let meta1 = PulseMeta(
+      debug: true,
+      trace: trace_id,
+      priority: .low,
+      tags: tags
+    )
+    
+    let meta2 = PulseMeta(
+      debug: true,
+      trace: trace_id,
+      priority: .low,
+      tags: tags
+    )
+    
+    #expect(meta1 == meta2)
+  }
+  
+  @Test("instances with different debug flags are not equal")
+  func instances_with_different_debug_flags_are_not_equal() throws {
+    let trace_id = UUID()
+    
+    let meta1 = PulseMeta(debug: true, trace: trace_id)
+    let meta2 = PulseMeta(debug: false, trace: trace_id)
+    
+    #expect(meta1 != meta2)
+  }
+  
+  @Test("instances with different trace ids are not equal")
+  func instances_with_different_trace_ids_are_not_equal() throws {
+    let meta1 = PulseMeta(trace: UUID())
+    let meta2 = PulseMeta(trace: UUID())
+    
+    #expect(meta1 != meta2)
+  }
+  
+  @Test("instances with different priorities are not equal")
+  func instances_with_different_priorities_are_not_equal() throws {
+    let meta1 = PulseMeta(priority: .high)
+    let meta2 = PulseMeta(priority: .low)
+    
+    #expect(meta1 != meta2)
+  }
+  
+  @Test("instances with different tags are not equal")
+  func instances_with_different_tags_are_not_equal() throws {
+    let meta1 = PulseMeta(tags: ["tag1"])
+    let meta2 = PulseMeta(tags: ["tag2"])
+    
+    #expect(meta1 != meta2)
+  }
+  
+  @Test("instances with different sources are not equal")
+  func instances_with_different_sources_are_not_equal() throws {
+    let source1 = PulseSource.From(source: TestRepresentable())
+    let source2 = PulseSource.From(source: TestRepresentable())
+    
+    let meta1 = PulseMeta(source: source1)
+    let meta2 = PulseMeta(source: source2)
+    
+    #expect(meta1 != meta2)
+  }
+  
+  @Test("instances with different echoes are not equal")
+  func instances_with_different_echoes_are_not_equal() throws {
+    let echo1 = PulseSource.From(source: TestRepresentable())
+    let echo2 = PulseSource.From(source: TestRepresentable())
+    
+    let meta1 = PulseMeta(echoes: echo1)
+    let meta2 = PulseMeta(echoes: echo2)
+    
+    #expect(meta1 != meta2)
+  }
+}

--- a/Tests/Flow/PulseTests/Metadata/PulseSourceTests.swift
+++ b/Tests/Flow/PulseTests/Metadata/PulseSourceTests.swift
@@ -1,0 +1,153 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Metadata: PulseSource")
+struct PulseSourceTests {
+  
+  // MARK: - Test Data
+  
+  struct TestRepresentable: Representable {
+    let id = UUID()
+    let name = "Test Representable"
+  }
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Pulsable")
+  func conforms_to_pulsable() throws {
+    let is_pulsable = (PulseSource.self as Any) is any Pulsable.Type
+    #expect(is_pulsable)
+  }
+  
+  @Test("conforms to Representable")
+  func conforms_to_representable() throws {
+    let is_representable = (PulseSource.self as Any) is any Representable.Type
+    #expect(is_representable)
+  }
+  
+  // MARK: - Factory Method Tests
+  
+  @Test("From(source:) preserves original id")
+  func from_source_preserves_original_id() throws {
+    // Given
+    let representable = TestRepresentable()
+    
+    // When
+    let source = PulseSource.From(source: representable)
+    
+    // Then
+    #expect(source.id == representable.id)
+  }
+  
+  @Test("From(source:) preserves original name")
+  func from_source_preserves_original_name() throws {
+    // Given
+    let representable = TestRepresentable()
+    
+    // When
+    let source = PulseSource.From(source: representable)
+    
+    // Then
+    #expect(source.name == representable.name)
+  }
+  
+  // MARK: - Identity Tests
+  
+  @Test("different instances have unique ids")
+  func different_instances_have_unique_ids() throws {
+    // Given
+    let representable1 = TestRepresentable()
+    let representable2 = TestRepresentable()
+    
+    // When
+    let source1 = PulseSource.From(source: representable1)
+    let source2 = PulseSource.From(source: representable2)
+    
+    // Then
+    #expect(source1.id != source2.id)
+  }
+  
+  @Test("instances created from same Representable have same ids")
+  func instances_from_same_representable_have_same_ids() throws {
+    // Given
+    let representable = TestRepresentable()
+    
+    // When
+    let source1 = PulseSource.From(source: representable)
+    let source2 = PulseSource.From(source: representable)
+    
+    // Then
+    #expect(source1.id == source2.id)
+  }
+  
+  // MARK: - Description Tests
+  
+  @Test("description combines name and id")
+  func description_combines_name_and_id() throws {
+    // Given
+    let representable = TestRepresentable()
+    let source = PulseSource.From(source: representable)
+    
+    // When
+    let description = source.description
+    
+    // Then
+    #expect(description == "\(source.name):\(source.id)")
+  }
+  
+  @Test("description uses inherited format from Representable")
+  func description_uses_inherited_format() throws {
+    // Given
+    let representable = TestRepresentable()
+    let source = PulseSource.From(source: representable)
+    
+    // When
+    let source_description = source.description
+    let representable_format = "\(source.name):\(source.id)"
+    
+    // Then
+    #expect(source_description == representable_format)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("instances with same properties are equal")
+  func instances_with_same_properties_are_equal() throws {
+    // Given
+    let representable = TestRepresentable()
+    
+    // When
+    let source1 = PulseSource.From(source: representable)
+    let source2 = PulseSource.From(source: representable)
+    
+    // Then
+    #expect(source1 == source2)
+  }
+  
+  @Test("instances with different properties are not equal")
+  func instances_with_different_properties_are_not_equal() throws {
+    // Given
+    let representable1 = TestRepresentable()
+    
+    // Create a custom representable with different properties
+    struct CustomRepresentable: Representable {
+      let id = UUID()
+      let name = "Different Representable"
+    }
+    let representable2 = CustomRepresentable()
+    
+    // When
+    let source1 = PulseSource.From(source: representable1)
+    let source2 = PulseSource.From(source: representable2)
+    
+    // Then
+    #expect(source1 != source2)
+  }
+}

--- a/Tests/Flow/PulseTests/Protocols/PulsableTests.swift
+++ b/Tests/Flow/PulseTests/Protocols/PulsableTests.swift
@@ -1,0 +1,185 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Protocols: Pulsable")
+struct PulsableTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulse: Pulsable {
+    let id: UUID
+    let message: String
+    let timestamp: Date
+  }
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Sendable")
+  func conforms_to_sendable() throws {
+    let is_sendable = (TestPulse.self as Any) is any Sendable.Type
+    #expect(is_sendable)
+  }
+  
+  @Test("conforms to Equatable")
+  func conforms_to_equatable() throws {
+    let is_equatable = (TestPulse.self as Any) is any Equatable.Type
+    #expect(is_equatable)
+  }
+  
+  @Test("conforms to Copyable")
+  func conforms_to_copyable() throws {
+    let is_copyable = (TestPulse.self as Any) is any Copyable.Type
+    #expect(is_copyable)
+  }
+  
+  @Test("conforms to Codable")
+  func conforms_to_codable() throws {
+    let is_codable = (TestPulse.self as Any) is any Codable.Type
+    #expect(is_codable)
+  }
+  
+  @Test("conforms to Hashable")
+  func conforms_to_hashable() throws {
+    let is_hashable = (TestPulse.self as Any) is any Hashable.Type
+    #expect(is_hashable)
+  }
+  
+  // MARK: - Encoding Tests
+  
+  @Test("can be encoded to JSON")
+  func can_be_encoded_to_json() throws {
+    // Given
+    let original = TestPulse(id: UUID(), message: "Test Message", timestamp: Date())
+    let encoder = JSONEncoder()
+    
+    // When/Then - Should not throw
+    let _ = try encoder.encode(original)
+  }
+  
+  @Test("can be decoded from JSON")
+  func can_be_decoded_from_json() throws {
+    // Given
+    let original = TestPulse(id: UUID(), message: "Test Message", timestamp: Date())
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    // When
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(TestPulse.self, from: data)
+    
+    // Then
+    #expect(decoded.id == original.id)
+    #expect(decoded.message == original.message)
+    #expect(decoded.timestamp.timeIntervalSince1970 == original.timestamp.timeIntervalSince1970)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("instances with same properties are equal")
+  func instances_with_same_properties_are_equal() throws {
+    // Given
+    let id = UUID()
+    let message = "Test Message"
+    let timestamp = Date()
+    
+    // When
+    let pulse1 = TestPulse(id: id, message: message, timestamp: timestamp)
+    let pulse2 = TestPulse(id: id, message: message, timestamp: timestamp)
+    
+    // Then
+    #expect(pulse1 == pulse2)
+  }
+  
+  @Test("instances with different ids are not equal")
+  func instances_with_different_ids_are_not_equal() throws {
+    // Given
+    let message = "Test Message"
+    let timestamp = Date()
+    
+    // When
+    let pulse1 = TestPulse(id: UUID(), message: message, timestamp: timestamp)
+    let pulse2 = TestPulse(id: UUID(), message: message, timestamp: timestamp)
+    
+    // Then
+    #expect(pulse1 != pulse2)
+  }
+  
+  @Test("instances with different messages are not equal")
+  func instances_with_different_messages_are_not_equal() throws {
+    // Given
+    let id = UUID()
+    let timestamp = Date()
+    
+    // When
+    let pulse1 = TestPulse(id: id, message: "Message 1", timestamp: timestamp)
+    let pulse2 = TestPulse(id: id, message: "Message 2", timestamp: timestamp)
+    
+    // Then
+    #expect(pulse1 != pulse2)
+  }
+  
+  @Test("instances with different timestamps are not equal")
+  func instances_with_different_timestamps_are_not_equal() throws {
+    // Given
+    let id = UUID()
+    let message = "Test Message"
+    
+    // When
+    let pulse1 = TestPulse(id: id, message: message, timestamp: Date())
+    let pulse2 = TestPulse(id: id, message: message, timestamp: Date(timeIntervalSinceNow: 100))
+    
+    // Then
+    #expect(pulse1 != pulse2)
+  }
+  
+  // MARK: - Hashable Tests
+  
+  @Test("equal instances have same hash value")
+  func equal_instances_have_same_hash_value() throws {
+    // Given
+    let id = UUID()
+    let message = "Test Message"
+    let timestamp = Date()
+    
+    // When
+    let pulse1 = TestPulse(id: id, message: message, timestamp: timestamp)
+    let pulse2 = TestPulse(id: id, message: message, timestamp: timestamp)
+    
+    // Then
+    #expect(pulse1.hashValue == pulse2.hashValue)
+  }
+  
+  @Test("different instances have different hash values")
+  func different_instances_have_different_hash_values() throws {
+    // Given
+    let pulse1 = TestPulse(id: UUID(), message: "Message 1", timestamp: Date())
+    let pulse2 = TestPulse(id: UUID(), message: "Message 2", timestamp: Date(timeIntervalSinceNow: 100))
+    
+    // When
+    let hash1 = pulse1.hashValue
+    let hash2 = pulse2.hashValue
+    
+    // Then
+    #expect(hash1 != hash2)
+  }
+  
+  @Test("can be used as dictionary key")
+  func can_be_used_as_dictionary_key() throws {
+    // Given
+    let pulse = TestPulse(id: UUID(), message: "Test Message", timestamp: Date())
+    var dictionary = [TestPulse: String]()
+    
+    // When
+    dictionary[pulse] = "Value"
+    
+    // Then
+    #expect(dictionary[pulse] == "Value")
+  }
+}

--- a/Tests/Flow/PulseTests/PulseTests.swift
+++ b/Tests/Flow/PulseTests/PulseTests.swift
@@ -1,0 +1,260 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Pulse/Core: Pulse")
+struct PulseTests {
+  
+  // MARK: - Test Data
+  
+  struct TestPulseData: Pulsable {
+    let value: String
+  }
+  
+  func create_test_data() -> TestPulseData {
+    return TestPulseData(value: "Test Value")
+  }
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Pulsable")
+  func conforms_to_pulsable() throws {
+    let is_pulsable = (Pulse<TestPulseData>.self as Any) is any Pulsable.Type
+    #expect(is_pulsable)
+  }
+  
+  @Test("conforms to Representable")
+  func conforms_to_representable() throws {
+    let is_representable = (Pulse<TestPulseData>.self as Any) is any Representable.Type
+    #expect(is_representable)
+  }
+  
+  // MARK: - Initialization Tests
+  
+  @Test("initialization creates pulse with provided data")
+  func initialization_creates_pulse_with_provided_data() throws {
+    let test_data = create_test_data()
+    let pulse = Pulse(test_data)
+    
+    #expect(pulse.data.value == "Test Value")
+  }
+  
+  @Test("initialization assigns unique id")
+  func initialization_assigns_unique_id() throws {
+    let test_data = create_test_data()
+    
+    let pulse1 = Pulse(test_data)
+    let pulse2 = Pulse(test_data)
+    
+    #expect(pulse1.id != pulse2.id)
+  }
+  
+  @Test("initialization sets timestamp to current time")
+  func initialization_sets_timestamp_to_current_time() throws {
+    let before = Date()
+    let pulse = Pulse(create_test_data())
+    let after = Date()
+    
+    #expect(pulse.timestamp >= before)
+    #expect(pulse.timestamp <= after)
+  }
+  
+  @Test("initialization creates default metadata with debug disabled")
+  func initialization_creates_default_metadata_with_debug_disabled() throws {
+    let pulse = Pulse(create_test_data())
+    #expect(!pulse.meta.debug)
+  }
+  
+  @Test("initialization creates default metadata with nil source")
+  func initialization_creates_default_metadata_with_nil_source() throws {
+    let pulse = Pulse(create_test_data())
+    #expect(pulse.meta.source == nil)
+  }
+  
+  @Test("initialization creates default metadata with nil echoes")
+  func initialization_creates_default_metadata_with_nil_echoes() throws {
+    let pulse = Pulse(create_test_data())
+    #expect(pulse.meta.echoes == nil)
+  }
+  
+  @Test("initialization creates default metadata with medium priority")
+  func initialization_creates_default_metadata_with_medium_priority() throws {
+    let pulse = Pulse(create_test_data())
+    #expect(pulse.meta.priority == TaskPriority.medium.rawValue)
+  }
+  
+  @Test("initialization creates default metadata with empty tags")
+  func initialization_creates_default_metadata_with_empty_tags() throws {
+    let pulse = Pulse(create_test_data())
+    #expect(pulse.meta.tags.isEmpty)
+  }
+  
+  // MARK: - Property Tests
+  
+  @Test("name returns formatted type name")
+  func name_returns_formatted_type_name() throws {
+    let pulse = Pulse(create_test_data())
+    
+    #expect(pulse.name == "Pulse:TestPulseData")
+  }
+  
+  @Test("priority returns strongly-typed TaskPriority")
+  func priority_returns_strongly_typed_task_priority() throws {
+    let pulse = Pulse(create_test_data())
+    
+    #expect(pulse.priority == .medium)
+    #expect(type(of: pulse.priority) == TaskPriority.self)
+  }
+  
+  @Test("description combines name and id")
+  func description_combines_name_and_id() throws {
+    let pulse = Pulse(create_test_data())
+    
+    #expect(pulse.description == "\(pulse.name):\(pulse.id)")
+  }
+  
+  // MARK: - Serialization Tests
+  
+  @Test("can be encoded to JSON")
+  func can_be_encoded_to_json() throws {
+    let pulse = Pulse(create_test_data())
+    let encoder = JSONEncoder()
+    
+    // Should not throw
+    let _ = try encoder.encode(pulse)
+  }
+  
+  @Test("can be decoded from JSON")
+  func can_be_decoded_from_json() throws {
+    let original = Pulse(create_test_data())
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(original)
+    let decoded = try decoder.decode(Pulse<TestPulseData>.self, from: data)
+    
+    #expect(decoded.id == original.id)
+    #expect(decoded.timestamp.timeIntervalSince1970 == original.timestamp.timeIntervalSince1970)
+    #expect(decoded.data.value == original.data.value)
+  }
+  
+  @Test("preserves metadata debug flag when serialized")
+  func preserves_metadata_debug_flag_when_serialized() throws {
+    // Create a pulse with non-default metadata for testing
+    let original = Pulse(create_test_data())
+    let meta = PulseMeta(debug: true)
+    let modified = Pulse(id: original.id, timestamp: original.timestamp, data: original.data, meta: meta)
+    
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(modified)
+    let decoded = try decoder.decode(Pulse<TestPulseData>.self, from: data)
+    
+    #expect(decoded.meta.debug == true)
+  }
+  
+  @Test("preserves metadata priority when serialized")
+  func preserves_metadata_priority_when_serialized() throws {
+    // Create a pulse with non-default metadata for testing
+    let original = Pulse(create_test_data())
+    let meta = PulseMeta(priority: .high)
+    let modified = Pulse(id: original.id, timestamp: original.timestamp, data: original.data, meta: meta)
+    
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(modified)
+    let decoded = try decoder.decode(Pulse<TestPulseData>.self, from: data)
+    
+    #expect(decoded.meta.priority == TaskPriority.high.rawValue)
+  }
+  
+  @Test("preserves metadata tags when serialized")
+  func preserves_metadata_tags_when_serialized() throws {
+    // Create a pulse with non-default metadata for testing
+    let original = Pulse(create_test_data())
+    let meta = PulseMeta(tags: ["test", "serialization"])
+    let modified = Pulse(id: original.id, timestamp: original.timestamp, data: original.data, meta: meta)
+    
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    
+    let data = try encoder.encode(modified)
+    let decoded = try decoder.decode(Pulse<TestPulseData>.self, from: data)
+    
+    #expect(decoded.meta.tags.contains("test"))
+    #expect(decoded.meta.tags.contains("serialization"))
+    #expect(decoded.meta.tags.count == 2)
+  }
+  
+  // MARK: - Equality Tests
+  
+  @Test("instances with same properties are equal")
+  func instances_with_same_properties_are_equal() throws {
+    // Create two pulse instances with identical properties
+    let id = UUID()
+    let timestamp = Date()
+    let data = create_test_data()
+    let meta = PulseMeta()
+    
+    let pulse1 = Pulse(id: id, timestamp: timestamp, data: data, meta: meta)
+    let pulse2 = Pulse(id: id, timestamp: timestamp, data: data, meta: meta)
+    
+    #expect(pulse1 == pulse2)
+  }
+  
+  @Test("instances with different ids are not equal")
+  func instances_with_different_ids_are_not_equal() throws {
+    let timestamp = Date()
+    let data = create_test_data()
+    let meta = PulseMeta()
+    
+    let pulse1 = Pulse(id: UUID(), timestamp: timestamp, data: data, meta: meta)
+    let pulse2 = Pulse(id: UUID(), timestamp: timestamp, data: data, meta: meta)
+    
+    #expect(pulse1 != pulse2)
+  }
+  
+  @Test("instances with different timestamps are not equal")
+  func instances_with_different_timestamps_are_not_equal() throws {
+    let id = UUID()
+    let data = create_test_data()
+    let meta = PulseMeta()
+    
+    let pulse1 = Pulse(id: id, timestamp: Date(), data: data, meta: meta)
+    let pulse2 = Pulse(id: id, timestamp: Date(timeIntervalSinceNow: 100), data: data, meta: meta)
+    
+    #expect(pulse1 != pulse2)
+  }
+  
+  @Test("instances with different data are not equal")
+  func instances_with_different_data_are_not_equal() throws {
+    let id = UUID()
+    let timestamp = Date()
+    let meta = PulseMeta()
+    
+    let pulse1 = Pulse(id: id, timestamp: timestamp, data: TestPulseData(value: "Value 1"), meta: meta)
+    let pulse2 = Pulse(id: id, timestamp: timestamp, data: TestPulseData(value: "Value 2"), meta: meta)
+    
+    #expect(pulse1 != pulse2)
+  }
+  
+  @Test("instances with different metadata are not equal")
+  func instances_with_different_metadata_are_not_equal() throws {
+    let id = UUID()
+    let timestamp = Date()
+    let data = create_test_data()
+    
+    let pulse1 = Pulse(id: id, timestamp: timestamp, data: data, meta: PulseMeta(debug: true))
+    let pulse2 = Pulse(id: id, timestamp: timestamp, data: data, meta: PulseMeta(debug: false))
+    
+    #expect(pulse1 != pulse2)
+  }
+}

--- a/Tests/Flow/StreamTests/Pulses/StreamReleasedTests.swift
+++ b/Tests/Flow/StreamTests/Pulses/StreamReleasedTests.swift
@@ -1,0 +1,36 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Stream/Types: StreamReleased")
+struct StreamReleasedTests {
+  
+  // MARK: - Protocol Conformance Tests
+  
+  @Test("conforms to Pulsable")
+  func conforms_to_pulsable() throws {
+    let is_pulsable = (StreamReleased.self as Any) is any Pulsable.Type
+    #expect(is_pulsable)
+  }
+  
+  // MARK: - Factory Method Tests
+  
+  @Test("Pulse creates a Pulse containing StreamReleased")
+  func pulse_creates_pulse_containing_stream_released() throws {
+    // Given
+    let id: UUID = UUID()
+
+    // When
+    let pulse = Pulse(StreamReleased(stream_id: id))
+    
+    // Then
+    #expect(type(of: pulse.data) == StreamReleased.self)
+    #expect(pulse.data.stream_id == id)
+  }
+}

--- a/Tests/Flow/StreamTests/StreamTests.swift
+++ b/Tests/Flow/StreamTests/StreamTests.swift
@@ -1,0 +1,218 @@
+// Copyright © 2025 Cassidy Spring (Bee). Obsidian Project.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Testing
+import Obsidian
+
+@testable import ObsidianFlow
+
+@Suite("Obsidian/Flow/Stream/Core: Stream")
+struct StreamTests {
+  
+  // MARK: - Test Data
+  
+  struct TestData: Pulsable {
+    let message: String
+  }
+  
+  func create_test_pulse() -> Pulse<TestData> {
+    return Pulse(TestData(message: "Test Message"))
+  }
+  
+  // MARK: - Initialization Tests
+  
+  @Test("initializes with data handler only")
+  func initializes_with_handler_only() throws {
+    let handler: ChannelHandler<TestData> = { _ in }
+    
+    let _ = Stream(handler: handler)
+    
+    // No assertion needed - the test passes if initialization doesn't throw
+  }
+  
+  @Test("initializes with all handlers")
+  func initializes_with_all_handlers() throws {
+    let handler: ChannelHandler<TestData> = { _ in }
+    let source_released: ChannelHandler<StreamReleased> = { _ in }
+    let anchor_released: ChannelHandler<StreamReleased> = { _ in }
+    
+    let _ = Stream(
+      source_released: source_released,
+      anchor_released: anchor_released,
+      handler: handler
+    )
+    
+    // No assertion needed - the test passes if initialization doesn't throw
+  }
+  
+  // MARK: - Send Tests
+  
+  @Test("send delivers pulse to data handler")
+  func send_delivers_pulse_to_handler() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let expected_message = pulse.data.message
+    
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestData> = { received_pulse in
+        #expect(received_pulse.data.message == expected_message)
+        confirm()
+      }
+      
+      let stream = Stream(handler: handler)
+      let result = await stream.send(pulse)
+      try await Task.sleep(for: .milliseconds(100))
+      
+      if case .success = result {
+        // Success case verified
+      } else {
+        #expect(Bool(false), "Expected success result from send")
+      }
+    }
+  }
+  
+  @Test("send returns error when stream is released")
+  func send_returns_error_when_stream_released() async throws {
+    // Given
+    let pulse = create_test_pulse()
+    let handler: ChannelHandler<TestData> = { _ in }
+    
+    let stream = Stream(handler: handler)
+    
+    // When
+    let release_result = await stream.release()
+    if case .failure = release_result {
+      #expect(Bool(false), "Stream release should have succeeded")
+    }
+    
+    // Then
+    let send_result = await stream.send(pulse)
+    
+    if case .failure(let error) = send_result {
+      if case .released = error {
+        // Success - got the released error as expected
+      } else {
+        #expect(Bool(false), "Expected released error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from send")
+    }
+  }
+  
+  // MARK: - Release Tests
+  
+  @Test("release succeeds")
+  func release_succeeds() async throws {
+    // Given
+    let handler: ChannelHandler<TestData> = { _ in }
+    
+    let stream = Stream(handler: handler)
+    
+    // When
+    let result = await stream.release()
+    
+    // Then
+    if case .success = result {
+      // Success case verified
+    } else {
+      #expect(Bool(false), "Expected success result from release")
+    }
+  }
+  
+  @Test("release fails when already released")
+  func release_fails_when_already_released() async throws {
+    // Given
+    let handler: ChannelHandler<TestData> = { _ in }
+    
+    let stream = Stream(handler: handler)
+    
+    // When
+    let first_result = await stream.release()
+    if case .failure = first_result {
+      #expect(Bool(false), "First stream release should have succeeded")
+    }
+    
+    // Then
+    let second_result = await stream.release()
+    
+    if case .failure(let error) = second_result {
+      if case .released = error {
+        // Success - got the released error as expected
+      } else {
+        #expect(Bool(false), "Expected released error but got different error")
+      }
+    } else {
+      #expect(Bool(false), "Expected failure result from second release")
+    }
+  }
+  
+  // MARK: - Notification Tests
+  
+  @Test("release notifies source released handler")
+  func release_notifies_source_released() async throws {
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestData> = { _ in }
+      
+      let source_released: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let stream = Stream(
+        source_released: source_released,
+        handler: handler
+      )
+      
+      let _ = await stream.release()
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("release notifies anchor released handler")
+  func release_notifies_anchor_released() async throws {
+    // When/Then
+    try await confirmation(expectedCount: 1) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestData> = { _ in }
+      
+      let anchor_released: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let stream = Stream(
+        anchor_released: anchor_released,
+        handler: handler
+      )
+      
+      let _ = await stream.release()
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+  
+  @Test("release notifies both handlers")
+  func release_notifies_both_handlers() async throws {
+    // When/Then
+    try await confirmation(expectedCount: 2) { (confirm) async throws -> Void in
+      let handler: ChannelHandler<TestData> = { _ in }
+      
+      let source_released: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let anchor_released: ChannelHandler<StreamReleased> = { _ in
+        confirm()
+      }
+      
+      let stream = Stream(
+        source_released: source_released,
+        anchor_released: anchor_released,
+        handler: handler
+      )
+      
+      let _ = await stream.release()
+      try await Task.sleep(for: .milliseconds(100))
+    }
+  }
+}


### PR DESCRIPTION
This is a big change. Originally I had started them as a single library (sable), being pulled from an app project. Then decided to separate them. That choice has made managing them both, for my purposes, untenable. So instead, Obsidian is becoming a monorepo package with multiple libraries. This change effectively depreciates Sable.