### PR TITLE
deps(swift): upgrade to 6.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,8 @@ jobs:
     name: test with swift ${{ matrix.swift }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-15, macos-14, ubuntu-latest]
-        swift: ["6.1"]
+        os: [macos-15, ubuntu-latest]
+        swift: ["6.2"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: beeauvin/swiftly-swift@v1

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 


### PR DESCRIPTION
Swift 6.2 has quite a few improvements that Obsidian would benefit greatly from. This will be a precursor to the v0.4.0 set of changes.